### PR TITLE
Projective cover

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.09-35",
+Version := "2022.09-36",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/examples/beilinson_quiver.g
+++ b/examples/beilinson_quiver.g
@@ -1,47 +1,40 @@
 LoadPackage( "FunctorCategories" );
 
-field := HomalgFieldOfRationals( );
+k := HomalgFieldOfRationals( );
 
-quiver := RightQuiver( 
+q := RightQuiver(
   "q(4)[x0:1->2,x1:1->2,x2:1->2,x3:1->2,y0:2->3,y1:2->3,y2:2->3,y3:2->3,z0:3->4,z1:3->4,z2:3->4,z3:3->4]" 
     );;
 
-Qq := PathAlgebra( field, quiver );;
+F := FreeCategory( q );
 
-A := QuotientOfPathAlgebra(
-  Qq,
-  [ 
-    Qq.x0 * Qq.y0 , Qq.y0 * Qq.z0,
-    Qq.x1 * Qq.y1 , Qq.y1 * Qq.z1,
-    Qq.x2 * Qq.y2 , Qq.y2 * Qq.z2,
-    Qq.x3 * Qq.y3 , Qq.y3 * Qq.z3,
-    Qq.x0 * Qq.y1 + Qq.x1 * Qq.y0,
-    Qq.x0 * Qq.y2 + Qq.x2 * Qq.y0,
-    Qq.x0 * Qq.y3 + Qq.x3 * Qq.y0,
-    Qq.x1 * Qq.y2 + Qq.x2 * Qq.y1,
-    Qq.x1 * Qq.y3 + Qq.x3 * Qq.y1,
-    Qq.x2 * Qq.y3 + Qq.x3 * Qq.y2,
-    Qq.y0 * Qq.z1 + Qq.y1 * Qq.z0,
-    Qq.y0 * Qq.z2 + Qq.y2 * Qq.z0,
-    Qq.y0 * Qq.z3 + Qq.y3 * Qq.z0,
-    Qq.y1 * Qq.z2 + Qq.y2 * Qq.z1,
-    Qq.y1 * Qq.z3 + Qq.y3 * Qq.z1,
-    Qq.y2 * Qq.z3 + Qq.y3 * Qq.z2
-  ]
-);;
+kF := k[F];
 
-algebroid := Algebroid( A );
+B := kF / [
+            kF.x0 * kF.y0 , kF.y0 * kF.z0,
+            kF.x1 * kF.y1 , kF.y1 * kF.z1,
+            kF.x2 * kF.y2 , kF.y2 * kF.z2,
+            kF.x3 * kF.y3 , kF.y3 * kF.z3,
+            kF.x0 * kF.y1 + kF.x1 * kF.y0,
+            kF.x0 * kF.y2 + kF.x2 * kF.y0,
+            kF.x0 * kF.y3 + kF.x3 * kF.y0,
+            kF.x1 * kF.y2 + kF.x2 * kF.y1,
+            kF.x1 * kF.y3 + kF.x3 * kF.y1,
+            kF.x2 * kF.y3 + kF.x3 * kF.y2,
+            kF.y0 * kF.z1 + kF.y1 * kF.z0,
+            kF.y0 * kF.z2 + kF.y2 * kF.z0,
+            kF.y0 * kF.z3 + kF.y3 * kF.z0,
+            kF.y1 * kF.z2 + kF.y2 * kF.z1,
+            kF.y1 * kF.z3 + kF.y3 * kF.z1,
+            kF.y2 * kF.z3 + kF.y3 * kF.z2
+          ];;
 
-matrix_cat := MatrixCategory( field );
+kmat := MatrixCategory( k );
 
-H := FunctorCategory( algebroid, matrix_cat );
+H := FunctorCategory( B, kmat );
 
-indec_projs := IndecProjectiveObjects( H );
+indec := Shuffle( Concatenation( IndecProjectiveObjects( H ), IndecInjectiveObjects( H ) ) );
 
-a := DirectSum( List( [ 1 .. 4 ], i -> Random( indec_projs ) ) );
+F := DirectSum( List( [ 1 .. 15 ], i -> Random( indec ) ) );
 
-b := DirectSum( List( [ 1 .. 4 ], i -> Random( indec_projs ) ) );
-
-Hom_a_b := HomStructure( a, b );
-
-B := BasisOfExternalHom( a, b );
+G := DirectSum( List( [ 1 .. 20 ], i -> Random( indec ) ) );

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -2398,17 +2398,21 @@ InstallMethod( IndecProjectiveObjects,
         [ IsFunctorCategory ],
         
   function ( Hom )
-    local A;
+    local A, A_oid_op, Y;
     
     A := UnderlyingQuiverAlgebra( Source( Hom ) );
     
     if not (IsMatrixCategory( Range( Hom ) ) and IsAdmissibleQuiverAlgebra( A )) then
       
-      TryNextMethod();
+      TryNextMethod( );
       
     fi;
     
-    return List( IndecProjRepresentations( A ), o -> ConvertToCellInFunctorCategory( o, Hom ) );
+    A_oid_op := OppositeAlgebroid( Source( Hom ) );
+    
+    Y := YonedaEmbedding( A_oid_op );
+    
+    return List( SetOfObjects( A_oid_op ), o -> ApplyFunctor( Y, o ) );
     
 end );
 

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -1991,73 +1991,17 @@ InstallMethodWithCache( FunctorCategory,
       SetIsAbelianCategoryWithEnoughInjectives( Hom, true );
       
       AddIsProjective( Hom,
-        { Hom, F } -> IsProjectiveRepresentation(
-                          ConvertToCellInCategoryOfQuiverRepresentations( F )
-                      )
-      );
+        { Hom, F } -> IsSplitEpimorphism( ProjectiveCover( F ) ) );
       
       AddIsInjective( Hom,
-        { Hom, F } -> IsInjectiveRepresentation(
-                          ConvertToCellInCategoryOfQuiverRepresentations( F )
-                      )
-      );
+        { Hom, F } -> IsSplitMonomorphism( InjectiveEnvelope( F ) ) );
       
       AddEpimorphismFromSomeProjectiveObject( Hom,
-        function( Hom, F )
-          local reps, R, epi, PR;
-          
-          reps := CategoryOfQuiverRepresentations( kq );
-          
-          R := ConvertToCellInCategoryOfQuiverRepresentations( F );
-          
-          epi := EpimorphismFromSomeProjectiveObject( reps, R );
-          
-          PR := ConvertToCellInFunctorCategory( Source( epi ), Hom );
-          
-          return ConvertToCellInFunctorCategory( PR, epi, F );
-          
-      end );
-
+        { Hom, F } -> ProjectiveCover( F ) );
+      
       AddMonomorphismIntoSomeInjectiveObject( Hom,
-        function( Hom, F )
-          local reps, R, mo, IR;
-          
-          reps := CategoryOfQuiverRepresentations( kq );
-          
-          R := ConvertToCellInCategoryOfQuiverRepresentations( F );
-          
-          mo := MonomorphismIntoSomeInjectiveObject( reps, R );
-          
-          IR := ConvertToCellInFunctorCategory( Range( mo ), Hom );
-          
-          return ConvertToCellInFunctorCategory( F, mo, IR );
-          
-      end );
+        { Hom, F } -> InjectiveEnvelope( F ) );
       
-      AddProjectiveLift( Hom,
-        { Hom, alpha, epi } ->
-            ConvertToCellInFunctorCategory(
-              Source( alpha ),
-              ProjectiveLift(
-                CategoryOfQuiverRepresentations( kq ),
-                ConvertToCellInCategoryOfQuiverRepresentations( alpha ),
-                ConvertToCellInCategoryOfQuiverRepresentations( epi ) ),
-              Source( epi )
-          )
-      );
-      
-      AddInjectiveColift( Hom,
-        { Hom, mono, alpha } ->
-            ConvertToCellInFunctorCategory(
-              Range( mono ),
-              InjectiveColift(
-                CategoryOfQuiverRepresentations( kq ),
-                ConvertToCellInCategoryOfQuiverRepresentations( mono ),
-                ConvertToCellInCategoryOfQuiverRepresentations( alpha ) ),
-              Range( alpha )
-          )
-      );
-    
     fi;
     
     if HasIsMonoidalCategory( C ) and IsMonoidalCategory( C ) and

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -2421,17 +2421,23 @@ InstallMethod( IndecInjectiveObjects,
         [ IsFunctorCategory ],
         
   function ( Hom )
-    local A;
+    local A, A_oid_op, Hom_op, indec_proj;
     
     A := UnderlyingQuiverAlgebra( Source( Hom ) );
     
     if not (IsMatrixCategory( Range( Hom ) ) and IsAdmissibleQuiverAlgebra( A )) then
-      
-      TryNextMethod();
+        
+        TryNextMethod( );
       
     fi;
     
-    return List( IndecInjRepresentations( A ), o -> ConvertToCellInFunctorCategory( o, Hom ) );
+    A_oid_op := OppositeAlgebroid( Source( Hom ) );
+    
+    Hom_op := FunctorCategory( A_oid_op, Range( Hom ) );
+    
+    indec_proj := IndecProjectiveObjects( Hom_op );
+    
+    return List( indec_proj, DualOfObjectInFunctorCategory );
     
 end );
 

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -2557,10 +2557,10 @@ InstallMethod( LaTeXOutput,
   function( F )
     local objs, v_objs, mors, v_mors, s, i;
     
-    objs := SetOfObjects( F );
+    objs := SetOfObjects( Source( F ) );
     v_objs := ValuesOfFunctor( F )[1];
     
-    mors := SetOfGeneratingMorphisms( F );
+    mors := SetOfGeneratingMorphisms( Source( F ) );
     v_mors := ValuesOfFunctor( F )[2];
     
     s := "\\begin{array}{ccc}\n ";
@@ -2605,7 +2605,7 @@ InstallMethod( LaTeXOutput,
     
     only_datum := ValueOption( "OnlyDatum" );
     
-    objs := SetOfObjects( eta );
+    objs := SetOfObjects( Source( Source( eta ) ) );
     
     v_objs := ValuesOnAllObjects( eta );
     

--- a/gap/Functors.gd
+++ b/gap/Functors.gd
@@ -115,3 +115,13 @@ DeclareAttribute( "SievesOfPathsToTruth", IsMorphismInFunctorCategory );
 #! @Group SievesOfPathsToTruth
 DeclareOperation( "SievesOfPathsToTruth",
         [ IsFunctorCategory, IsMorphismInFunctorCategory ] );
+
+DeclareAttribute( "RadicalFunctorAttr", IsFunctorCategory );
+
+#! @Description
+#!  The input is a Hom-category <A>H</A><C>:=Hom(B,C)</C>, where <C>B</C> is a f.p. algebroid and
+#!  <C>C</C> is a matrix category over some homalg field <C>K</C>.
+#!  The output is the radical endofunctor on <A>H</A>.
+#! @Arguments H
+#! @Returns a &CAP; functor
+DeclareOperation( "RadicalFunctor", [ IsFunctorCategory ] );

--- a/gap/Functors.gi
+++ b/gap/Functors.gi
@@ -511,3 +511,30 @@ InstallMethod( SievesOfPathsToTruth,
     return SievesOfPathsToTruth( CapCategory( iota ), iota );
     
 end );
+
+##
+InstallMethod( RadicalFunctorAttr,
+        [ IsFunctorCategory ],
+        
+  function( Hom )
+    local rad;
+    
+    rad := CapFunctor( "Radical endofunctor", Hom, Hom );
+    
+    AddObjectFunction( rad,
+      F -> Source( RadicalInclusion( F ) )
+    );
+    
+    AddMorphismFunction( rad,
+      { s, eta, r } -> LiftAlongMonomorphism(
+                          PreCompose( RadicalInclusion( Source( eta ) ), eta ),
+                          RadicalInclusion( Range( eta ) )
+                        )
+    );
+    
+    return rad;
+    
+end );
+
+##
+InstallMethod( RadicalFunctor, [ IsFunctorCategory ], RadicalFunctorAttr );

--- a/gap/HomologicalMethods.gd
+++ b/gap/HomologicalMethods.gd
@@ -17,3 +17,9 @@ DeclareAttribute( "ProjectiveCover", IsObjectInFunctorCategory );
 DeclareAttribute( "DualOfObjectInFunctorCategory", IsObjectInFunctorCategory );
 
 DeclareAttribute( "DualOfMorphismInFunctorCategory", IsMorphismInFunctorCategory );
+
+DeclareAttribute( "MorphismsIntoDirectSumDecompositionOfInjectiveEnvelope", IsObjectInFunctorCategory );
+
+DeclareAttribute( "DirectSumDecompositionOfInjectiveObject", IsObjectInFunctorCategory );
+
+DeclareAttribute( "InjectiveEnvelope", IsObjectInFunctorCategory );

--- a/gap/HomologicalMethods.gd
+++ b/gap/HomologicalMethods.gd
@@ -13,3 +13,7 @@ DeclareAttribute( "MorphismsFromDirectSumDecompositionOfProjectiveCover", IsObje
 DeclareAttribute( "DirectSumDecompositionOfProjectiveObject", IsObjectInFunctorCategory );
 
 DeclareAttribute( "ProjectiveCover", IsObjectInFunctorCategory );
+
+DeclareAttribute( "DualOfObjectInFunctorCategory", IsObjectInFunctorCategory );
+
+DeclareAttribute( "DualOfMorphismInFunctorCategory", IsMorphismInFunctorCategory );

--- a/gap/HomologicalMethods.gd
+++ b/gap/HomologicalMethods.gd
@@ -5,3 +5,11 @@
 #
 
 DeclareAttribute( "RadicalInclusion", IsObjectInFunctorCategory );
+
+DeclareOperation( "CoverElementByProjectiveObject", [ IsObjectInFunctorCategory, IsCapCategoryMorphism, IsInt ] );
+
+DeclareAttribute( "MorphismsFromDirectSumDecompositionOfProjectiveCover", IsObjectInFunctorCategory );
+
+DeclareAttribute( "DirectSumDecompositionOfProjectiveObject", IsObjectInFunctorCategory );
+
+DeclareAttribute( "ProjectiveCover", IsObjectInFunctorCategory );

--- a/gap/HomologicalMethods.gd
+++ b/gap/HomologicalMethods.gd
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FunctorCategories: Categories of functors
+#
+# Declarations
+#
+
+DeclareAttribute( "RadicalInclusion", IsObjectInFunctorCategory );

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -172,3 +172,63 @@ InstallMethod( ProjectiveCover,
     return UniversalMorphismFromDirectSumWithGivenDirectSum( Hom, List( dec, Source ), F, dec, D );
     
 end );
+
+##
+InstallMethod( DualOfObjectInFunctorCategory,
+          [ IsObjectInFunctorCategory ],
+          
+  function ( F )
+    local Hom, B, kvec, Hom_op, images_of_morphisms, D_F;
+    
+    Hom := CapCategory( F );
+    
+    B := Source( Hom );
+    
+    kvec := Range( Hom );
+    
+    if not IsMatrixCategory( kvec ) then
+        
+        Error( "The range category should be a category of matrices" );
+        
+    fi;
+    
+    Hom_op := FunctorCategory( OppositeAlgebroid( B ), kvec );
+    
+    images_of_morphisms := List( ValuesOfFunctor( F )[2], v -> TransposedMatrix( UnderlyingMatrix( v ) ) / kvec );
+    
+    D_F := AsObjectInFunctorCategoryByValues( Hom_op, ValuesOfFunctor( F )[1], images_of_morphisms );
+    
+    SetDualOfObjectInFunctorCategory( D_F, F );
+    
+    return D_F;
+    
+end );
+
+##
+InstallMethod( DualOfMorphismInFunctorCategory,
+        [ IsMorphismInFunctorCategory ],
+        
+  function ( eta )
+    local Hom, F, G, Hom_op, B_op, kvec, images_of_objects, D_eta;
+    
+    Hom := CapCategory( eta );
+    
+    F := DualOfObjectInFunctorCategory( Source( eta ) );
+    
+    G := DualOfObjectInFunctorCategory( Range( eta ) );
+    
+    Hom_op := CapCategory( F );
+    
+    B_op := Source( Hom_op );
+    
+    kvec := Range( Hom_op );
+    
+    images_of_objects := List( ValuesOnAllObjects( eta ), v -> TransposedMatrix( UnderlyingMatrix( v ) ) / kvec );
+    
+    D_eta := AsMorphismInFunctorCategoryByValues( Hom, G, images_of_objects, F );
+    
+    SetDualOfMorphismInFunctorCategory( D_eta, eta );
+    
+    return D_eta;
+    
+end );

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -59,6 +59,9 @@ InstallMethod( RadicalInclusion,
     
 end );
 
+
+##
+## See Lemma 2.83 at http://dx.doi.org/10.25819/ubsi/10144
 ##
 InstallMethod( CoverElementByProjectiveObject,
         [ IsObjectInFunctorCategory, IsCapCategoryMorphism, IsInt ],
@@ -129,9 +132,9 @@ InstallMethod( MorphismsFromDirectSumDecompositionOfProjectiveCover,
           return List( iotas, iota -> CoverElementByProjectiveObject( F, iota, i ) );
           
         end );
-    
+        
         return Concatenation( dec );
-    
+        
 end );
 
 ##
@@ -241,12 +244,13 @@ InstallMethod( MorphismsIntoDirectSumDecompositionOfInjectiveEnvelope,
 
 ##
 InstallMethod( DirectSumDecompositionOfInjectiveObject,
-        [ IsObjectInFunctorCategory ],
+        [ IsObjectInFunctorCategory ], # and is injective
         
-  F -> List( DirectSumDecompositionOfProjectiveObject( DualOfObjectInFunctorCategory( F ) ), DualOfMorphismInFunctorCategory ) );
+  MorphismsIntoDirectSumDecompositionOfInjectiveEnvelope );
 
 ##
 InstallMethod( InjectiveEnvelope,
         [ IsObjectInFunctorCategory ],
         
   F -> DualOfMorphismInFunctorCategory( ProjectiveCover( DualOfObjectInFunctorCategory( F ) ) ) );
+

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# FunctorCategories: Categories of functors
+#
+# Implementations
+#
+
+##
+InstallMethod( RadicalInclusion,
+          [ IsObjectInFunctorCategory ],
+          
+  function ( F )
+    local Hom, algebroid, objs, mors, val_objs, val_mors, pos, im, RF, embedding_of_radical;
+    
+    Hom := CapCategory( F );
+    
+    algebroid := Source( Hom );
+    
+    objs := SetOfObjects( algebroid );
+    
+    mors := SetOfGeneratingMorphisms( algebroid );
+    
+    val_objs := ValuesOfFunctor( F )[1];
+    
+    val_mors := ListOfValues( ValuesOfFunctor( F )[2] );
+    
+    pos := List( objs, o -> PositionsProperty( mors, m -> IsEqualForObjects( o, Range( m ) ) ) );
+    
+    im := List( pos, p -> val_mors{ p } );
+    
+    im :=
+      ListN( im, val_objs,
+        function( l, o )
+          if IsEmpty( l ) then
+            return UniversalMorphismFromZeroObject( o );
+          else
+            return ImageEmbedding( MorphismBetweenDirectSums( TransposedMat( [ l ] ) ) );
+          fi;
+        end );
+      
+    val_objs := List( im, Source );
+    
+    val_mors :=
+      ListN( mors, val_mors,
+        function( m, vm )
+          local s, r;
+          s := Position( objs, Source( m ) );
+          r := Position( objs, Range( m ) );
+          return LiftAlongMonomorphism( im[ r ], PreCompose( im[ s ], vm ) );
+        end );
+    
+    RF := AsObjectInFunctorCategoryByValues( Hom, val_objs, val_mors );
+    
+    embedding_of_radical := AsMorphismInFunctorCategoryByValues( Hom, RF, im, F );
+    
+    Assert( 4, IsMonomorphism( embedding_of_radical ) );
+    SetIsMonomorphism( embedding_of_radical, true );
+    
+    return embedding_of_radical;
+    
+end );

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -232,3 +232,21 @@ InstallMethod( DualOfMorphismInFunctorCategory,
     return D_eta;
     
 end );
+
+##
+InstallMethod( MorphismsIntoDirectSumDecompositionOfInjectiveEnvelope,
+        [ IsObjectInFunctorCategory ],
+        
+  F -> List( MorphismsFromDirectSumDecompositionOfProjectiveCover( DualOfObjectInFunctorCategory( F ) ), DualOfMorphismInFunctorCategory ) );
+
+##
+InstallMethod( DirectSumDecompositionOfInjectiveObject,
+        [ IsObjectInFunctorCategory ],
+        
+  F -> List( DirectSumDecompositionOfProjectiveObject( DualOfObjectInFunctorCategory( F ) ), DualOfMorphismInFunctorCategory ) );
+
+##
+InstallMethod( InjectiveEnvelope,
+        [ IsObjectInFunctorCategory ],
+        
+  F -> DualOfMorphismInFunctorCategory( ProjectiveCover( DualOfObjectInFunctorCategory( F ) ) ) );

--- a/init.g
+++ b/init.g
@@ -8,6 +8,7 @@ ReadPackage( "FunctorCategories", "gap/FunctorCategories.gd");
 ReadPackage( "FunctorCategories", "gap/HomStructure.gd");
 ReadPackage( "FunctorCategories", "gap/Functors.gd");
 ReadPackage( "FunctorCategories", "gap/DirectSumDecomposition.gd");
+ReadPackage( "FunctorCategories", "gap/HomologicalMethods.gd");
 ReadPackage( "FunctorCategories", "gap/FiniteCocompletion.gd");
 ReadPackage( "FunctorCategories", "gap/CategoryOfQuivers.gd");
 ReadPackage( "FunctorCategories", "gap/FiniteCompletion.gd");

--- a/read.g
+++ b/read.g
@@ -11,6 +11,7 @@ ReadPackage( "FunctorCategories", "gap/FunctorCategories.gi");
 ReadPackage( "FunctorCategories", "gap/HomStructure.gi");
 ReadPackage( "FunctorCategories", "gap/Functors.gi");
 ReadPackage( "FunctorCategories", "gap/DirectSumDecomposition.gi");
+ReadPackage( "FunctorCategories", "gap/HomologicalMethods.gi");
 ReadPackage( "FunctorCategories", "gap/FiniteCocompletion.gi");
 ReadPackage( "FunctorCategories", "gap/CategoryOfQuivers.gi");
 ReadPackage( "FunctorCategories", "gap/FiniteCompletion.gi");


### PR DESCRIPTION
This draft PR contains an implementation for the projective cover of a functor, the returned projective cover is a direct sum of objects in the image of the `YonedaEmbedding` functor. We can discuss the compatibility with `YonedaProjectives` the next time we skype.
A step toward closing https://github.com/homalg-project/FunctorCategories/issues/14