### PR TITLE
Improve HomStructure methods

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -15,7 +15,7 @@ Version := Maximum( [
                    ## this line prevents merge conflicts
                    "2018.10-18", ## Florian's version
                    ## this line prevents merge conflicts
-                   "2021.02-15", ## Kamal's version
+                   "2021.04-02", ## Kamal's version
                    ## this line prevents merge conflicts
                    "2020.09-01", ## Tibor's version
                    ] ),

--- a/gap/HomStructure.gd
+++ b/gap/HomStructure.gd
@@ -4,8 +4,6 @@
 # Declarations
 #
 
-DeclareProperty( "IsQuiverVertexWithLoop", IsQuiverVertex );
-
 DeclareOperation( "AuxiliaryMorphism",
     [ IsCapCategoryObjectInHomCategory, IsCapCategoryObjectInHomCategory ] );
 


### PR DESCRIPTION
* Loops agnostic,
* Avoid computing the auxiliary morphism many times.

```
LoadPackage( "FunctorCategories" );
field := HomalgFieldOfRationals( );
#  x    a
#    1 ---> 2
#    |      |
#  c |      | b
#    v      v
#    3 ---> 4
#       d     y
#
quiver := RightQuiver( "q(4)[x:1->1,a:1->2,b:2->4,c:1->3,d:3->4,y:4->4]" );
A := PathAlgebra( field, quiver );;
A := A / [ A.x^3, A.y^2 ];
algebroid := Algebroid( A );
matrix_cat := MatrixCategory( field );
H := Hom( algebroid, matrix_cat );
indec_projs := IndecProjectiveObjects( H );
a := DirectSum( List( [ 1 .. 15 ], i -> Random( indec_projs ) ) );
#! <(1)->9, (2)->11, (3)->14, (4)->60; (x)->9x9, (a)->9x11, (b)->11x60, (c)->9x14, (d)->14x60, (y)->60x60>
b := DirectSum( List( [ 1 .. 15 ], i -> Random( indec_projs ) ) );
#! <(1)->15, (2)->17, (3)->20, (4)->80; (x)->15x15, (a)->15x17, (b)->17x80, (c)->15x20, (d)->20x80, (y)->80x80>
```

Without this PR, we have the following timing:
```
gap> CallFuncListWithTime( HomStructure, [a,b] );
21.715058 Secs.
<A vector space object over Q of dimension 579>
gap> CallFuncListWithTime( BasisOfExternalHom, [a,b] );;
65.154113 Secs.
gap> eta := Random( last ); zeta := Random( last2 );
gap> CallFuncListWithTime( HomStructure, [ eta, zeta ] );;
93.725376 Secs.
```
With this PR, we have the following timing:
```
gap> CallFuncListWithTime( HomStructure, [a,b] );
7.206672 Secs.
<A vector space object over Q of dimension 579>
gap> CallFuncListWithTime( BasisOfExternalHom, [a,b] );;
48.185195 Secs.
gap> eta := Random( last ); zeta := Random( last2 );
gap> CallFuncListWithTime( HomStructure, [ eta, zeta ] );;
24.968106 Secs.
```