### PR TITLE
Add missing local variables

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.05-01",
+Version := "2022.05-02",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -442,6 +442,7 @@ InstallMethod( \.,
         [ IsObjectInFunctorCategory, IsPosInt ],
         
   function ( F, string_as_int )
+    local name;
     
     name := NameRNam( string_as_int );
     
@@ -455,6 +456,7 @@ InstallMethod( \.,
         [ IsMorphismInFunctorCategory, IsPosInt ],
         
   function ( eta, string_as_int )
+    local name;
     
     name := NameRNam( string_as_int );
     


### PR DESCRIPTION
4ti2Interface (a transitively suggested dependency) uses `name` as a global
variable, so this only pops up as a warning if 4ti2Interface is not
available.