### PR TITLE
Update conversion methods (quiver reps <-> functors)

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.06-25",
+Version := "2022.06-26",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -2102,54 +2102,73 @@ InstallMethodWithCache( FunctorCategory,
        IsAdmissibleQuiverAlgebra( kq ) then
       
       SetIsAbelianCategoryWithEnoughProjectives( Hom, true );
-      
       SetIsAbelianCategoryWithEnoughInjectives( Hom, true );
       
       AddIsProjective( Hom,
-        { Hom, F } -> IsProjectiveRepresentation( Hom,
+        { Hom, F } -> IsProjectiveRepresentation(
                           ConvertToCellInCategoryOfQuiverRepresentations( F )
                       )
       );
       
       AddIsInjective( Hom,
-        { Hom, F } -> IsInjectiveRepresentation( Hom,
+        { Hom, F } -> IsInjectiveRepresentation(
                           ConvertToCellInCategoryOfQuiverRepresentations( F )
                       )
       );
       
       AddEpimorphismFromSomeProjectiveObject( Hom,
-        { Hom, F } -> ConvertToCellInFunctorCategory(
-                        EpimorphismFromSomeProjectiveObject( Hom,
-                          ConvertToCellInCategoryOfQuiverRepresentations( F )
-                        )
-                      )
-      );
-      
+        function( Hom, F )
+          local reps, R, epi, PR;
+          
+          reps := CategoryOfQuiverRepresentations( kq );
+          
+          R := ConvertToCellInCategoryOfQuiverRepresentations( F );
+          
+          epi := EpimorphismFromSomeProjectiveObject( reps, R );
+          
+          PR := ConvertToCellInFunctorCategory( Source( epi ), Hom );
+          
+          return ConvertToCellInFunctorCategory( PR, epi, F );
+          
+      end );
+
       AddMonomorphismIntoSomeInjectiveObject( Hom,
-        { Hom, F } -> ConvertToCellInFunctorCategory(
-                        MonomorphismIntoSomeInjectiveObject( Hom,
-                          ConvertToCellInCategoryOfQuiverRepresentations( F )
-                        )
-                      )
-      );
+        function( Hom, F )
+          local reps, R, mo, IR;
+          
+          reps := CategoryOfQuiverRepresentations( kq );
+          
+          R := ConvertToCellInCategoryOfQuiverRepresentations( F );
+          
+          mo := MonomorphismIntoSomeInjectiveObject( reps, R );
+          
+          IR := ConvertToCellInFunctorCategory( Range( mo ), Hom );
+          
+          return ConvertToCellInFunctorCategory( F, mo, IR );
+          
+      end );
       
       AddProjectiveLift( Hom,
         { Hom, alpha, epi } ->
             ConvertToCellInFunctorCategory(
-            ProjectiveLift( Hom,
-              ConvertToCellInCategoryOfQuiverRepresentations( alpha ),
-              ConvertToCellInCategoryOfQuiverRepresentations( epi )
-            )
+              Source( alpha ),
+              ProjectiveLift(
+                CategoryOfQuiverRepresentations( kq ),
+                ConvertToCellInCategoryOfQuiverRepresentations( alpha ),
+                ConvertToCellInCategoryOfQuiverRepresentations( epi ) ),
+              Source( epi )
           )
       );
       
       AddInjectiveColift( Hom,
         { Hom, mono, alpha } ->
             ConvertToCellInFunctorCategory(
-            InjectiveColift( Hom,
-              ConvertToCellInCategoryOfQuiverRepresentations( mono ),
-              ConvertToCellInCategoryOfQuiverRepresentations( alpha )
-            )
+              Range( mono ),
+              InjectiveColift(
+                CategoryOfQuiverRepresentations( kq ),
+                ConvertToCellInCategoryOfQuiverRepresentations( mono ),
+                ConvertToCellInCategoryOfQuiverRepresentations( alpha ) ),
+              Range( alpha )
           )
       );
     
@@ -2506,7 +2525,7 @@ InstallMethod( IndecProjectiveObjects,
       
     fi;
     
-    return List( IndecProjRepresentations( A ), ConvertToCellInFunctorCategory );
+    return List( IndecProjRepresentations( A ), o -> ConvertToCellInFunctorCategory( o, Hom ) );
     
 end );
 
@@ -2525,7 +2544,7 @@ InstallMethod( IndecInjectiveObjects,
       
     fi;
     
-    return List( IndecInjRepresentations( A ), ConvertToCellInFunctorCategory );
+    return List( IndecInjRepresentations( A ), o -> ConvertToCellInFunctorCategory( o, Hom ) );
     
 end );
 
@@ -2544,7 +2563,7 @@ InstallMethod( SimpleObjects,
       
     fi;
     
-    return List( SimpleRepresentations( A ), ConvertToCellInFunctorCategory );
+    return List( SimpleRepresentations( A ), o -> ConvertToCellInFunctorCategory( o, Hom ) );
     
 end );
 

--- a/gap/Functors.gd
+++ b/gap/Functors.gd
@@ -11,8 +11,9 @@
 #
 ####################################
 
-DeclareAttribute( "ConvertToCellInFunctorCategory", IsQuiverRepresentation );
-DeclareAttribute( "ConvertToCellInFunctorCategory", IsQuiverRepresentationHomomorphism );
+DeclareOperation( "ConvertToCellInFunctorCategory", [ IsQuiverRepresentation, IsFunctorCategory ] );
+DeclareOperation( "ConvertToCellInFunctorCategory", [ IsObjectInFunctorCategory, IsQuiverRepresentationHomomorphism, IsObjectInFunctorCategory ] );
+
 DeclareAttribute( "ConvertToCellInCategoryOfQuiverRepresentations", IsObjectInFunctorCategory );
 DeclareAttribute( "ConvertToCellInCategoryOfQuiverRepresentations", IsMorphismInFunctorCategory );
 

--- a/gap/Functors.gi
+++ b/gap/Functors.gi
@@ -8,49 +8,37 @@ BindGlobal( "FUNCTOR_CATEGORIES", rec( QQ := HomalgFieldOfRationals( ) ) );
 
 ##
 InstallMethod( ConvertToCellInFunctorCategory,
-    [ IsQuiverRepresentation ],
+    [ IsQuiverRepresentation, IsFunctorCategory ],
     
-  function ( rep )
-    local reps, A, A_oid, k, dims, matrices, F;
+  function ( rep, Hom )
+    local A, k_mat, k, dims, maps;
     
-    reps := CapCategory( rep );
+    A := Source( Hom );
     
-    A := AlgebraOfCategory( reps );
-    
-    A_oid := Algebroid( A );
-    
-    k := CommutativeRingOfLinearCategory( A_oid );
+    k := UnderlyingRing( Range( Hom ) );
     
     dims := DimensionVector( rep );
     
-    matrices := List( MatricesOfRepresentation( rep ),
+    maps := List( MatricesOfRepresentation( rep ),
       mat -> HomalgMatrix(
                 RowsOfMatrix( mat ),
                   DimensionsMat( mat )[ 1 ],
                     DimensionsMat( mat )[ 2 ], k ) );
     
-    F := AsObjectInFunctorCategory( A_oid, dims, matrices );
-    
-    SetConvertToCellInCategoryOfQuiverRepresentations( F, rep );
-    
-    return F;
+    return AsObjectInFunctorCategory( A, dims, maps );
     
 end );
 
 ##
 InstallMethod( ConvertToCellInFunctorCategory,
-          [ IsQuiverRepresentationHomomorphism ],
-          
-  function ( phi )
-    local reps, A, A_oid, k, e, F, G, eta;
+          [ IsObjectInFunctorCategory, IsQuiverRepresentationHomomorphism, IsObjectInFunctorCategory ],
+
+  function ( F, phi, G )
+    local A, k, e;
     
-    reps := CapCategory( phi );
+    A := Source( CapCategory( F ) );
     
-    A := AlgebraOfCategory( reps );
-    
-    A_oid := Algebroid( A );
-    
-    k := CommutativeRingOfLinearCategory( A_oid );
+    k := UnderlyingRing( Range( CapCategory( F ) ) );
     
     e := List( MatricesOfRepresentationHomomorphism( phi ),
           mat -> HomalgMatrix(
@@ -58,14 +46,7 @@ InstallMethod( ConvertToCellInFunctorCategory,
                       DimensionsMat( mat )[ 1 ],
                         DimensionsMat( mat )[ 2 ], k ) );
     
-    F := ConvertToCellInFunctorCategory( Source( phi ) );
-    G := ConvertToCellInFunctorCategory( Range( phi ) );
-    
-    eta := AsMorphismInFunctorCategory( F, e, G );
-    
-    SetConvertToCellInCategoryOfQuiverRepresentations( eta, phi );
-    
-    return eta;
+    return AsMorphismInFunctorCategory( F, e, G );
     
 end );
 
@@ -86,13 +67,9 @@ InstallMethod( IsomorphismFromCategoryOfQuiverRepresentations,
     
     I := CapFunctor( name, reps, functors );
     
-    AddObjectFunction( I,
-      rep -> ConvertToCellInFunctorCategory( rep )
-    );
+    AddObjectFunction( I, F -> ConvertToCellInFunctorCategory( F, functors ) );
     
-    AddMorphismFunction( I,
-      { S, phi, R } -> ConvertToCellInFunctorCategory( phi )
-    );
+    AddMorphismFunction( I, { F, phi, G } -> ConvertToCellInFunctorCategory( F, phi, G ) );
     
     return I;
     
@@ -103,7 +80,7 @@ InstallMethod( ConvertToCellInCategoryOfQuiverRepresentations,
           [ IsObjectInFunctorCategory ],
           
   function ( F )
-    local B, A, k, dims, matrices, rep;
+    local B, A, k, dims, matrices;
     
     B := Source( F );
     
@@ -122,11 +99,7 @@ InstallMethod( ConvertToCellInCategoryOfQuiverRepresentations,
                                       )
                     );
     
-    rep := QuiverRepresentation( A, dims, matrices );
-    
-    SetConvertToCellInFunctorCategory( rep, F );
-    
-    return rep;
+    return QuiverRepresentation( A, dims, matrices );
     
 end );
 
@@ -135,7 +108,7 @@ InstallMethod( ConvertToCellInCategoryOfQuiverRepresentations,
           [ IsMorphismInFunctorCategory ],
           
   function ( eta )
-    local B, A, k, matrices, S, R, phi;
+    local B, A, k, matrices, S, R;
     
     B := Source( CapCategory( eta ) );
     
@@ -156,11 +129,7 @@ InstallMethod( ConvertToCellInCategoryOfQuiverRepresentations,
     
     R := ConvertToCellInCategoryOfQuiverRepresentations( Range( eta ) );
     
-    phi := QuiverRepresentationHomomorphism( S, R, matrices );
-    
-    SetConvertToCellInFunctorCategory( phi, eta );
-    
-    return phi;
+    return QuiverRepresentationHomomorphism( S, R, matrices );
     
 end );
 


### PR DESCRIPTION
1) The old methods are buggy because algebroids are not necessarily attributes to the underlying quiver algebra.
2) ~~Change the number of derived methods from 290 to 292 in `examples/TerminalCategory.g` so that ci-tests pass~~.