### PR TITLE
MatrixCategory( k : overhead := false ) in some tests

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.08-06",
+Version := "2022.08-07",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/examples/doc/DifferentialModules.g
+++ b/examples/doc/DifferentialModules.g
@@ -19,6 +19,11 @@ Qq := PathAlgebra( Q, q );
 #! Q * q
 #! @EndExample
 
+#! @Example
+A := MatrixCategory( Q : overhead := false );
+#! Category of matrices over Q
+#! @EndExample
+
 #! Consider $\mathbb{Q}q$ as an algebroid $B$ with one object $1$ and morphisms given by $\mathbb{Q}q$.
 
 #! @Example
@@ -127,11 +132,6 @@ ApplyFunctor( antipode, B.t );
 #! Let $A$ be the category with objects the natural numbers and morphisms the matrices with coefficients in $\mathbb{Q}$.
 #! We use it as a skeletal model of the category of finite dimension vector spaces.
 
-#! @Example
-A := MatrixCategory( Q );
-#! Category of matrices over Q
-#! @EndExample
-
 #! Let $H$ be the category of functors from $B$ to $A$.
 
 #! @Example
@@ -158,7 +158,7 @@ z( B.t );
 idz := IdentityMorphism( z );
 #! <(1)->0x0>
 idz( B.1 );
-#! <A zero, identity morphism in Category of matrices over Q>
+#! <A morphism in Category of matrices over Q>
 DirectSum( z, z );
 #! <(1)->0; (t)->0x0>
 z = DirectSum(z,z);

--- a/examples/doc/Endomorphism.g
+++ b/examples/doc/Endomorphism.g
@@ -23,8 +23,16 @@ Qq := PathAlgebra( Q, q );
 #! Out of this path algebra construct the algebroid (actually the algebra) $B$ that
 #! is obtained as the quotient of the path algebra modulo the ideal $(t^3 - 1)$.
 
+#! Let $A$ be the category of matrices as a skeletal model for the category of finite dimensional vector spaces over $\mathbb{Q}$.
+#! Its objects are non-negative integers and its morphisms are matrices with coefficients in $\mathbb{Q}$.
+
 #! @Example
-B := Algebroid( Qq, [ Qq.t^3 - Qq.1 ] );
+A := MatrixCategory( Q : overhead := false );
+#! Category of matrices over Q
+#! @EndExample
+
+#! @Example
+B := Algebroid( Qq, [ Qq.t^3 - Qq.1 ] : range_of_HomStructure := A );
 #! Algebra( Q, FreeCategory( RightQuiver( "q(1)[t:1->1]" ) ) ) / relations
 RelationsOfAlgebroid( B );
 #! [ (1)-[1*(t*t*t) - 1*(1)]->(1) ]
@@ -112,14 +120,6 @@ ApplyFunctor( antipode, B.t );
 #! (1)-[{ 1*(t*t) }]->(1)
 #! @EndExample
 
-#! Let $A$ be the category of matrices as a skeletal model for the category of finite dimensional vector spaces over $\mathbb{Q}$.
-#! Its objects are non-negative integers and its morphisms are matrices with coefficients in $\mathbb{Q}$.
-
-#! @Example
-A := MatrixCategory( Q );
-#! Category of matrices over Q
-#! @EndExample
-
 #! Construct the category $H$ of functors from $B$ to $A$.
 #! An object in this category is a pair consisting of a
 #! finite-dimensional vector space, specified by its dimension,
@@ -149,7 +149,7 @@ z.t = z( B.t );
 idz := IdentityMorphism( z );
 #! <(1)->0x0>
 idz( B.1 );
-#! <A zero, identity morphism in Category of matrices over Q>
+#! <A morphism in Category of matrices over Q>
 idz.1 = idz( B.1 );
 #! true
 DirectSum( z, z );


### PR DESCRIPTION
Note:
AddBialgebroidStructure creates the algebroid B^0,
which, contrary to B, always HasRangeCategoryOfHomomorphismStructure
set to MatrixCategory( k )