### PR TITLE
Adjust to https://github.com/homalg-project/CAP_project/pull/1017

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.09-01",
+Version := "2022.09-02",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/examples/TerminalCategory.g
+++ b/examples/TerminalCategory.g
@@ -8,7 +8,7 @@ T := FiniteCompletion( InitialCategory( ) );
 IsTerminalCategory( T );
 #! true
 InfoOfInstalledOperationsOfCategory( T );
-#! 492 primitive operations were used to derive 524 operations for this category
+#! 488 primitive operations were used to derive 520 operations for this category
 #! which constructively
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing


### PR DESCRIPTION
TerminalCategory cannot compute
IsomorphismFromFiberProductToEqualizerOfDirectProductDiagram and
IsomorphismFromPushoutToCoequalizerOfCoproductDiagram
anymore.
The previous behavior was a bug because
IsomorphismFromFiberProductToKernelOfDiagonalDifference and
IsomorphismFromPushoutToCokernelOfDiagonalDifference
are installed and are incompatible to the the derivations from the
(co-)equalizer.