### PR TITLE
pass the option `supports_empty_limits` to legacy CategoryConstructor

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.09-02",
+Version := "2022.09-03",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
@@ -94,7 +94,7 @@ Dependencies := rec(
                    [ "RingsForHomalg", ">= 2020.02.04" ],
                    [ "LinearAlgebraForCAP", ">= 2020.01.10" ],
                    [ "FreydCategoriesForCAP", ">= 2019.11.02" ],
-                   [ "CategoryConstructor", ">= 2022.06-03" ],
+                   [ "CategoryConstructor", ">= 2022.09-03" ],
                    [ "SubcategoriesForCAP", ">= 2021.12-01" ],
                    [ "Toposes", ">= 2022.06-09" ],
                    [ "FinSetsForCAP", ">= 2022.05-05" ],

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -865,7 +865,7 @@ InstallMethodWithCache( FunctorCategory,
     local kq, A, relations, B_op, source, name, list_of_operations,
           create_func_bool, create_func_object, create_func_morphism,
           list_of_operations_to_install, skip, func, pos, commutative_ring,
-          properties, preinstall, doc, prop, Hom, vertices, arrows, H;
+          properties, preinstall, supports_empty_limits, doc, prop, Hom, vertices, arrows, H;
     
     if IsFpCategory( B ) then
         kq := UnderlyingQuiverAlgebra( B );
@@ -1355,9 +1355,16 @@ InstallMethodWithCache( FunctorCategory,
     CAP_INTERNAL_METHOD_NAME_RECORD.ImageObject.functorial := "ImageObjectFunctorial";
     CAP_INTERNAL_METHOD_NAME_RECORD.CoimageObject.functorial := "CoimageObjectFunctorial";
     
+    if IsBound( C!.supports_empty_limits ) then
+        supports_empty_limits := C!.supports_empty_limits;
+    else
+        supports_empty_limits := false;
+    fi;
+    
     Hom := CategoryConstructor( :
                    name := name,
                    category_as_first_argument := true,
+                   supports_empty_limits := true,
                    category_object_filter := IsObjectInFunctorCategory,
                    category_morphism_filter := IsMorphismInFunctorCategory,
                    category_filter := IsFunctorCategory,
@@ -1374,12 +1381,6 @@ InstallMethodWithCache( FunctorCategory,
                    underlying_object_getter_string := "( { cat, F } -> UnderlyingCapTwoCategoryCell( F ) )",
                    underlying_morphism_getter_string := "( { cat, eta } -> UnderlyingCapTwoCategoryCell( eta ) )"
                    );
-    
-    if IsBound( C!.supports_empty_limits ) then
-        
-        Hom!.supports_empty_limits := C!.supports_empty_limits;
-        
-    fi;
     
     SetOppositeOfSource( Hom, B_op );
     


### PR DESCRIPTION
needs CategoryConstructor v2022.09-03

this avoids warning introduced in CAP v2022.09-09 in this PR:

https://github.com/homalg-project/CAP_project/pull/1026