### PR TITLE
fixed previous commit

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.09-03",
+Version := "2022.09-04",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -1364,7 +1364,7 @@ InstallMethodWithCache( FunctorCategory,
     Hom := CategoryConstructor( :
                    name := name,
                    category_as_first_argument := true,
-                   supports_empty_limits := true,
+                   supports_empty_limits := supports_empty_limits,
                    category_object_filter := IsObjectInFunctorCategory,
                    category_morphism_filter := IsMorphismInFunctorCategory,
                    category_filter := IsFunctorCategory,


### PR DESCRIPTION
pass option `supports_empty_limits` properly to legacy CategoryConstructor