### PR TITLE
fixed bug in AddInterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.09-05",
+Version := "2022.09-06",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/HomStructure.gi
+++ b/gap/HomStructure.gi
@@ -209,7 +209,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_HOMOMORPHISM_STRUCTURE_TO_FUNCTOR_CATEG
         tau := ListOfValues( List( ValuesOnAllObjects( eta ),
                        eta_o -> InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( C, eta_o ) ) );
         
-        diagram := List( tau, Source );
+        diagram := List( tau, Range );
         
         return KernelLift( H,
                        AuxiliaryMorphism( Hom,


### PR DESCRIPTION
no current tests or packages detected this obvious syntactic bug; it was detected by the future commits during testing the code with the option `no_precompiled_code`, which caused a different range category of the Hom structure to be chosen by Algebroids v2022.08-03