### PR TITLE
Adjust the implementation of `CoverElementByProjectiveObject` ...

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.09-36",
+Version := "2022.09-37",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -232,7 +232,7 @@ InstallMethod( DualOfMorphismInFunctorCategory,
     
     images_of_objects := List( ValuesOnAllObjects( eta ), v -> TransposedMatrix( UnderlyingMatrix( v ) ) / kvec );
     
-    D_eta := AsMorphismInFunctorCategoryByValues( Hom, G, images_of_objects, F );
+    D_eta := AsMorphismInFunctorCategoryByValues( Hom_op, G, images_of_objects, F );
     
     SetDualOfMorphismInFunctorCategory( D_eta, eta );
     

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -67,28 +67,32 @@ InstallMethod( CoverElementByProjectiveObject,
         [ IsObjectInFunctorCategory, IsCapCategoryMorphism, IsInt ],
         
   function ( F, l, n )
-    local Hom, algebroid, C, vertices, v, P_v, val_objs;
+    local Hom, B, B_op, C, vertices, v, P_v, val_objs;
     
     Hom := CapCategory( F );
     
-    algebroid := Source( Hom );
-    
     C := Range( Hom );
     
-    vertices := SetOfObjects( algebroid );
-     
+    B := Source( Hom );
+    
+    B_op := OppositeAlgebroid( B );
+    
+    vertices := SetOfObjects( B_op );
+    
     v := vertices[ n ];
-     
+    
     P_v := IndecProjectiveObjects( Hom )[ n ];
     
-    val_objs := List( vertices, u -> List( BasisOfExternalHom( v, u ), m -> PreCompose( l, F( m ) ) ) );
+    val_objs := List( vertices, u ->
+                  List( BasisOfExternalHom( u, v ), m ->
+                    PreCompose( l, F( OppositeAlgebraElement( UnderlyingQuiverAlgebraElement( m ) ) / B ) ) ) );
     
     val_objs := ListN(
                   ValuesOfFunctor( P_v )[1],
                   val_objs,
                   ValuesOfFunctor( F )[1],
                   { s, tau, r } -> UniversalMorphismFromDirectSumWithGivenDirectSum( C, List( tau, Source ), r, tau, s ) );
-                
+    
     return AsMorphismInFunctorCategoryByValues( Hom, P_v, val_objs, F );
     
 end );


### PR DESCRIPTION
... to the current implementation of YonedaEmbedding `B^op -> FunctorCategory(B, k-mat)` which (now) relies on the Hom Structure of `B_op` rather than that of `B`.