### PR TITLE
Make sure AutoDoc comments appear right before the declaration

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.10-08",
+Version := "2022.10-09",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/PreSheaves.gd
+++ b/gap/PreSheaves.gd
@@ -282,6 +282,7 @@ DeclareAttribute( "CreatePreSheaf",
 DeclareOperation( "CreatePreSheaf",
         [ IsCapCategory, IsRecord, IsRecord ] );
 
+if false then
 #! @Description
 #!  Another alternative input is the source category <A>B</A> and two defining lists <A>images_of_objects</A> and <A>images_of_morphisms</A> of <A>F</A>.
 #!  The order of their entries must correspond to that of the vertices and arrows of the underlying quiver.
@@ -294,7 +295,6 @@ DeclareOperation( "CreatePreSheaf",
 #!  in <C>MatrixCategory</C>( $k$ ), respectively.
 #! @Arguments B, images_of_objects, images_of_morphisms
 #! @Group CreatePreSheaf
-if false then
 DeclareOperation( "CreatePreSheaf",
         [ IsCapCategory, IsList, IsList ] );
 fi;


### PR DESCRIPTION
Otherwise CreatePreSheafMorphismByValues appears in the wrong group. https://github.com/gap-packages/AutoDoc/issues/267 tries to clarify if this is a bug in AutoDoc or working as intended.