### PR TITLE
Support CategoryOfRows as an alternative for MatrixCategory

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.10-10",
+Version := "2022.10-11",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/DirectSumDecomposition.gi
+++ b/gap/DirectSumDecomposition.gi
@@ -12,7 +12,7 @@ InstallMethod( DecomposeOnceByRandomEndomorphism,
   function ( F )
     local d, endbas, k, n, random, b, alpha, i, alpha2, keremb;
     
-    d := Maximum( List( ValuesOfFunctor( F )[1], Dimension ) );
+    d := Maximum( List( ValuesOfFunctor( F )[1], ObjectDatum ) );
     
     if d = 0 then
         return fail;

--- a/gap/FunctorCategories.gd
+++ b/gap/FunctorCategories.gd
@@ -346,7 +346,7 @@ DeclareOperation( "AsObjectInFunctorCategory",
 #!  <A>images_of_morphisms</A> is a list of matrices, and
 #!  $k:=$ <C>CommutativeRingOfLinearCategory</C>( B ) is a field
 #!  then the two lists are interpreted as objects and morphisms
-#!  in <C>MatrixCategory</C>( $k$ ), respectively.
+#!  in a matrix category or a category of rows over $k$, respectively.
 #! @Arguments B, images_of_objects, images_of_morphisms
 #! @Group AsObjectInFunctorCategory
 DeclareOperation( "AsObjectInFunctorCategory",

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -281,7 +281,17 @@ InstallMethod( AsObjectInFunctorCategory,
         TryNextMethod();
     fi;
     
-    kmat := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "MatrixCategory", MatrixCategory( k ) );
+    if HasRangeCategoryOfHomomorphismStructure( kq ) then
+        
+        kmat := RangeCategoryOfHomomorphismStructure( kq );
+        
+    else
+        
+        kmat := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "MatrixCategory", MatrixCategory( k ) );
+        
+    fi;
+    
+    Assert( 0, IsMatrixCategory( kmat ) or IsCategoryOfRows( kmat ) );
     
     objects := List( dims, dim -> dim / kmat );
     
@@ -642,7 +652,7 @@ InstallMethodWithCache( FunctorCategory,
         
     fi;
     
-    if IsMatrixCategory( C ) and
+    if (IsMatrixCategory( C ) or IsCategoryOfRows( C )) and
        HasUnderlyingQuiverAlgebra( B ) and
        IsFiniteDimensional( UnderlyingQuiverAlgebra( B ) ) and
        IsAdmissibleQuiverAlgebra( UnderlyingQuiverAlgebra( B ) ) then
@@ -698,7 +708,17 @@ InstallMethodWithCache( FunctorCategory,
   function ( B, k )
     local kmat, Hom;
     
-    kmat := MatrixCategory( k : overhead := false );
+    if HasRangeCategoryOfHomomorphismStructure( B ) then
+        
+        kmat := RangeCategoryOfHomomorphismStructure( B );
+        
+    else
+        
+        kmat := MatrixCategory( k : overhead := false );
+        
+    fi;
+    
+    Assert( 0, IsMatrixCategory( kmat ) or IsCategoryOfRows( kmat ) );
     
     CapCategorySwitchLogicOn( kmat );
     
@@ -840,7 +860,7 @@ InstallMethod( IndecProjectiveObjects,
     
     A := UnderlyingQuiverAlgebra( Source( Hom ) );
     
-    if not (IsMatrixCategory( Range( Hom ) ) and IsAdmissibleQuiverAlgebra( A )) then
+    if not ((IsMatrixCategory( Range( Hom ) ) or IsCategoryOfRows( Range( Hom ) )) and IsAdmissibleQuiverAlgebra( A )) then
       
       TryNextMethod( );
       
@@ -863,7 +883,7 @@ InstallMethod( IndecInjectiveObjects,
     
     A := UnderlyingQuiverAlgebra( Source( Hom ) );
     
-    if not (IsMatrixCategory( Range( Hom ) ) and IsAdmissibleQuiverAlgebra( A )) then
+    if not ((IsMatrixCategory( Range( Hom ) ) or IsCategoryOfRows( Range( Hom ) )) and IsAdmissibleQuiverAlgebra( A )) then
         
         TryNextMethod( );
       
@@ -888,7 +908,7 @@ InstallMethod( SimpleObjects,
     
     A := UnderlyingQuiverAlgebra( Source( Hom ) );
     
-    if not (IsMatrixCategory( Range( Hom ) ) and IsAdmissibleQuiverAlgebra( A )) then
+    if not ((IsMatrixCategory( Range( Hom ) ) or IsCategoryOfRows( Range( Hom ) )) and IsAdmissibleQuiverAlgebra( A )) then
       
       TryNextMethod();
       
@@ -910,7 +930,7 @@ InstallMethod( ViewObj,
   function ( F )
     local algebroid, vertices, arrows, v_dim, v_string, a_dim, a_string, string;
     
-    if not IsMatrixCategory( Range( CapCategory( F ) ) ) then
+    if not (IsMatrixCategory( Range( CapCategory( F ) ) ) or IsCategoryOfRows( Range( CapCategory( F ) ) )) then
       
       TryNextMethod();
       
@@ -920,7 +940,7 @@ InstallMethod( ViewObj,
     
     vertices := List( SetOfObjects( algebroid ), UnderlyingVertex );
     
-    v_dim := List( ValuesOfFunctor( F )[1], Dimension );
+    v_dim := List( ValuesOfFunctor( F )[1], ObjectDatum );
     
     v_string := ListN( vertices, v_dim, { vertex, dim } -> Concatenation( "(", String( vertex ), ")->", String( dim ) ) );
     
@@ -938,7 +958,7 @@ InstallMethod( ViewObj,
       
     fi;
     
-    a_dim := List( ValuesOfFunctor( F )[2], m -> [ Dimension( Source( m ) ), Dimension( Range( m ) ) ] );
+    a_dim := List( ValuesOfFunctor( F )[2], m -> [ ObjectDatum( Source( m ) ), ObjectDatum( Range( m ) ) ] );
     
     a_string := ListN( arrows, a_dim,
                   { arrow, dim } -> Concatenation(
@@ -998,7 +1018,7 @@ InstallMethod( ViewObj,
   function ( eta )
     local vertices, s_dim, r_dim, string;
     
-    if not IsMatrixCategory( Range( CapCategory( eta ) ) ) then
+    if not (IsMatrixCategory( Range( CapCategory( eta ) ) ) or IsCategoryOfRows( Range( CapCategory( eta ) ) )) then
       
       TryNextMethod();
       
@@ -1006,9 +1026,9 @@ InstallMethod( ViewObj,
     
     vertices := List( SetOfObjects( Source( Source( eta ) ) ), UnderlyingVertex );
      
-    s_dim := List( ValuesOfFunctor( Source( eta ) )[1], Dimension );
+    s_dim := List( ValuesOfFunctor( Source( eta ) )[1], ObjectDatum );
     
-    r_dim := List( ValuesOfFunctor( Range( eta ) )[1], Dimension );
+    r_dim := List( ValuesOfFunctor( Range( eta ) )[1], ObjectDatum );
    
     string := ListN( vertices, s_dim, r_dim,
                 { vertex, s, r } ->

--- a/gap/Functors.gi
+++ b/gap/Functors.gi
@@ -88,7 +88,7 @@ InstallMethod( ConvertToCellInCategoryOfQuiverRepresentations,
     
     k := LeftActingDomain( A );
     
-    dims := List( ListOfValues( ValuesOfFunctor( F )[1] ), Dimension );
+    dims := List( ListOfValues( ValuesOfFunctor( F )[1] ), ObjectDatum );
     
     matrices := List( ListOfValues( ValuesOfFunctor( F )[2] ), UnderlyingMatrix );
     

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -127,7 +127,7 @@ InstallMethod( MorphismsFromDirectSumDecompositionOfProjectiveCover,
         function( pre_image, i )
           local m, n, D, iotas;
           
-          n := Dimension( Source( pre_image ) );
+          n := ObjectDatum( Source( pre_image ) );
           
           D := ListWithIdenticalEntries( n, k );
           
@@ -193,9 +193,9 @@ InstallMethod( DualOfObjectInFunctorCategory,
     
     kvec := Range( Hom );
     
-    if not IsMatrixCategory( kvec ) then
+    if not IsMatrixCategory( kvec ) and not IsCategoryOfRows( kvec ) then
         
-        Error( "The range category should be a category of matrices" );
+        Error( "The range category should be a category of matrices or rows" );
         
     fi;
     

--- a/gap/PreSheaves.gd
+++ b/gap/PreSheaves.gd
@@ -292,7 +292,7 @@ if false then
 #!  <A>images_of_morphisms</A> is a list of matrices, and
 #!  $k:=$ <C>CommutativeRingOfLinearCategory</C>( B ) is a field
 #!  then the two lists are interpreted as objects and morphisms
-#!  in <C>MatrixCategory</C>( $k$ ), respectively.
+#!  in a matrix category or a category of rows over $k$, respectively.
 #! @Arguments B, images_of_objects, images_of_morphisms
 #! @Group CreatePreSheaf
 DeclareOperation( "CreatePreSheaf",

--- a/gap/PreSheaves.gi
+++ b/gap/PreSheaves.gi
@@ -406,7 +406,17 @@ InstallOtherMethod( CreatePreSheaf,
         TryNextMethod();
     fi;
     
-    kmat := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "MatrixCategory", MatrixCategory( k ) );
+    if HasRangeCategoryOfHomomorphismStructure( kq ) then
+        
+        kmat := RangeCategoryOfHomomorphismStructure( kq );
+        
+    else
+        
+        kmat := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "MatrixCategory", MatrixCategory( k ) );
+        
+    fi;
+    
+    Assert( 0, IsMatrixCategory( kmat ) or IsCategoryOfRows( kmat ) );
     
     objects := List( dims, dim -> dim / kmat );
     
@@ -1953,7 +1963,17 @@ InstallMethodWithCache( PreSheaves,
   function ( B, k )
     local kmat, PSh;
     
-    kmat := MatrixCategory( k : overhead := false );
+    if HasRangeCategoryOfHomomorphismStructure( B ) then
+        
+        kmat := RangeCategoryOfHomomorphismStructure( B );
+        
+    else
+        
+        kmat := MatrixCategory( k : overhead := false );
+        
+    fi;
+    
+    Assert( 0, IsMatrixCategory( kmat ) or IsCategoryOfRows( kmat ) );
     
     CapCategorySwitchLogicOn( kmat );
     
@@ -2332,7 +2352,7 @@ InstallMethod( ViewObj,
   function ( F )
     local algebroid, vertices, arrows, v_dim, v_string, a_dim, a_string, string;
     
-    if not IsMatrixCategory( Range( F ) ) then
+    if not (IsMatrixCategory( Range( F ) ) or IsCategoryOfRows( Range( F ) )) then
       
       TryNextMethod();
       
@@ -2342,7 +2362,7 @@ InstallMethod( ViewObj,
     
     vertices := List( SetOfObjects( algebroid ), UnderlyingVertex );
     
-    v_dim := List( ValuesOfPreSheaf( F )[1], Dimension );
+    v_dim := List( ValuesOfPreSheaf( F )[1], ObjectDatum );
     
     v_string := ListN( vertices, v_dim, { vertex, dim } -> Concatenation( "(", String( vertex ), ")->", String( dim ) ) );
     
@@ -2360,7 +2380,7 @@ InstallMethod( ViewObj,
       
     fi;
     
-    a_dim := List( ValuesOfPreSheaf( F )[2], m -> [ Dimension( Source( m ) ), Dimension( Range( m ) ) ] );
+    a_dim := List( ValuesOfPreSheaf( F )[2], m -> [ ObjectDatum( Source( m ) ), ObjectDatum( Range( m ) ) ] );
     
     a_string := ListN( arrows, a_dim,
                   { arrow, dim } -> Concatenation(
@@ -2420,7 +2440,7 @@ InstallMethod( ViewObj,
   function ( eta )
     local vertices, s_dim, r_dim, string;
     
-    if not IsMatrixCategory( Range( CapCategory( eta ) ) ) then
+    if not (IsMatrixCategory( Range( CapCategory( eta ) ) ) or IsCategoryOfRows( Range( CapCategory( eta ) ) )) then
       
       TryNextMethod();
       
@@ -2428,9 +2448,9 @@ InstallMethod( ViewObj,
     
     vertices := List( SetOfObjects( Source( Source( eta ) ) ), UnderlyingVertex );
      
-    s_dim := List( ValuesOfPreSheaf( Source( eta ) )[1], Dimension );
+    s_dim := List( ValuesOfPreSheaf( Source( eta ) )[1], ObjectDatum );
     
-    r_dim := List( ValuesOfPreSheaf( Range( eta ) )[1], Dimension );
+    r_dim := List( ValuesOfPreSheaf( Range( eta ) )[1], ObjectDatum );
    
     string := ListN( vertices, s_dim, r_dim,
                 { vertex, s, r } ->


### PR DESCRIPTION
This PR does not switch to CategoryOfRows by default due to the problem described in https://github.com/homalg-project/FunctorCategories/issues/184#issuecomment-1276371357. However, it makes the code compatible with using CategoryOfRows, and uses the range category of the homomorphism structure of an algebroids if available. This allows to switch Algebroids to use CategoryOfRows.