### PR TITLE
Bump version

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.10-20",
+Version := "2022.10-21",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),


### PR DESCRIPTION
Currently FunctorCategories has the same version as AutoDoc, but with a hyphen instead of a dot. This leads to obscure package loading errors due to https://github.com/gap-system/gap/pull/5157.