### PR TITLE
use ExactCoverWithGlobalElements to generalize code for UnitOfIsbellAdjunctionData

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.11-27",
+Version := "2022.11-28",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
@@ -98,8 +98,8 @@ Dependencies := rec(
                    [ "FreydCategoriesForCAP", ">= 2019.11.02" ],
                    [ "CategoryConstructor", ">= 2022.11-02" ],
                    [ "SubcategoriesForCAP", ">= 2021.12-01" ],
-                   [ "Toposes", ">= 2022.11-02" ],
-                   [ "FinSetsForCAP", ">= 2022.11-04" ],
+                   [ "Toposes", ">= 2022.11-03" ],
+                   [ "FinSetsForCAP", ">= 2022.11-05" ],
                    ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/doc/Doc.autodoc
+++ b/doc/Doc.autodoc
@@ -119,3 +119,5 @@
 @Subsection The reflexive completion of the one object category $C_2$
 
 @InsertChunk C2
+
+@InsertChunk ReflexiveModules

--- a/examples/ReflexiveModules.g
+++ b/examples/ReflexiveModules.g
@@ -1,0 +1,93 @@
+#! @Chunk ReflexiveModules
+
+LoadPackage( "FunctorCategories" );
+
+#! @Example
+q := RightQuiver( "q(1)[t:1->1]" );
+#! q(1)[t:1->1]
+F := FreeCategory( q );
+#! FreeCategory( RightQuiver( "q(1)[t:1->1]" ) )
+Q := HomalgFieldOfRationals( );
+#! Q
+Qq := Q[F];
+#! Algebra( Q, FreeCategory( RightQuiver( "q(1)[t:1->1]" ) ) )
+A := Qq / [ Qq.t^3 ];
+#! Algebra( Q, FreeCategory( RightQuiver( "q(1)[t:1->1]" ) ) ) / relations
+PSh := PreSheaves( A );
+#! PreSheaves(
+#! Algebra( Q, FreeCategory( RightQuiver( "q(1)[t:1->1]" ) ) ) / relations,
+#! Rows( Q ) )
+CommutativeRingOfLinearCategory( PSh );
+#! Q
+Display( PSh.1 );
+#! Image of <(1)>:
+#! A row module over Q of rank 3
+#! 
+#! Image of (1)-[{ 1*(t) }]->(1):
+#! Source:
+#! A row module over Q of rank 3
+#! 
+#! Matrix:
+#! [ [  0,  1,  0 ],
+#!   [  0,  0,  1 ],
+#!   [  0,  0,  0 ] ]
+#! 
+#! Range:
+#! A row module over Q of rank 3
+#! 
+#! A morphism in Rows( Q )
+#! 
+#! An object in PreSheaves(
+#! Algebra( Q, FreeCategory( RightQuiver( "q(1)[t:1->1]" ) ) ) / relations,
+#! Rows( Q ) ) given by the above data
+Display( PSh.t );
+#! Image of <(1)>:
+#! Source:
+#! A row module over Q of rank 3
+#! 
+#! Matrix:
+#! [ [  0,  1,  0 ],
+#!   [  0,  0,  1 ],
+#!   [  0,  0,  0 ] ]
+#! 
+#! Range:
+#! A row module over Q of rank 3
+#! 
+#! A morphism in Rows( Q )
+#! 
+#! A morphism in PreSheaves(
+#! Algebra( Q, FreeCategory( RightQuiver( "q(1)[t:1->1]" ) ) ) / relations,
+#! Rows( Q ) ) given by the above data
+phi := PreCompose( PSh.t, PSh.t );
+#! <(1)->3x3>
+V := DirectSum( [ PSh.1, KernelObject( phi ), ImageObject( phi ) ] );
+#! <(1)->6; (t)->6x6>
+Display( V );
+#! Image of <(1)>:
+#! A row module over Q of rank 6
+#! 
+#! Image of (1)-[{ 1*(t) }]->(1):
+#! Source:
+#! A row module over Q of rank 6
+#! 
+#! Matrix:
+#! [ [  0,  1,  0,  0,  0,  0 ],
+#!   [  0,  0,  1,  0,  0,  0 ],
+#!   [  0,  0,  0,  0,  0,  0 ],
+#!   [  0,  0,  0,  0,  1,  0 ],
+#!   [  0,  0,  0,  0,  0,  0 ],
+#!   [  0,  0,  0,  0,  0,  0 ] ]
+#! 
+#! Range:
+#! A row module over Q of rank 6
+#! 
+#! A morphism in Rows( Q )
+#! 
+#! An object in PreSheaves(
+#! Algebra( Q, FreeCategory( RightQuiver( "q(1)[t:1->1]" ) ) ) / relations,
+#! Rows( Q ) ) given by the above data
+IsProjective( V );
+#! false
+IsReflexive( V );
+#! true
+#! @EndExample

--- a/examples/notebooks/PastingLawForPullbacks.ipynb
+++ b/examples/notebooks/PastingLawForPullbacks.ipynb
@@ -176,7 +176,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "57 primitive operations were used to derive 276 operations for this category which algorithmically\n",
+      "58 primitive operations were used to derive 277 operations for this category which algorithmically\n",
       "* IsEquippedWithHomomorphismStructure\n",
       "* IsElementaryTopos\n",
       "and furthermore mathematically\n",

--- a/gap/Functors.gi
+++ b/gap/Functors.gi
@@ -377,7 +377,7 @@ InstallMethodForCompilerForCAP( UnitOfIsbellAdjunctionData,
         [ IsPreSheafCategory, IsCoPreSheafCategory ],
         
   function ( PSh, coPSh )
-    local B, H, T, objs, nr_objs, O, Spec, Yoneda, coYoneda;
+    local B, H, objs, nr_objs, O, Spec, Yoneda, coYoneda;
     
     B := Source( PSh );
     
@@ -385,13 +385,11 @@ InstallMethodForCompilerForCAP( UnitOfIsbellAdjunctionData,
     Assert( 0, IsIdenticalObj( B, Source( coPSh ) ) );
     
     #% CAP_JIT_DROP_NEXT_STATEMENT
-    if not ( IsFpCategory( B ) and HasRangeCategoryOfHomomorphismStructure( B ) ) then
+    if not HasRangeCategoryOfHomomorphismStructure( B ) then
         TryNextMethod( );
     fi;
     
     H := Range( PSh );
-    
-    T := DistinguishedObjectOfHomomorphismStructure( PSh );
     
     objs := SetOfObjects( B );
     nr_objs := DefiningPairOfUnderlyingQuiver( PSh )[1];
@@ -415,14 +413,14 @@ InstallMethodForCompilerForCAP( UnitOfIsbellAdjunctionData,
             
             return UniversalMorphismFromCoproduct( H,
                            Fvv( a ), # := coPSh( B( a, - ), Fv )
-                           List( MorphismsOfExternalHom( T, F( a ) ), x ->
+                           List( ExactCoverWithGlobalElements( H, F( a ) ), x ->
                                  InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructure( coPSh,
                                          CreateCoPreSheafMorphismByValues( coPSh, # ∈ coPSh( B( a, - ), Fv )
                                                  coYoneda( a ), # := B( a, - )
                                                  List( objs, b ->
                                                        UniversalMorphismFromCoproduct( H, # Fv( b ) := PSh( F, B( -, b ) ) → B( a, b )
                                                                coYoneda( a )( b ), # := B( a, b )
-                                                               List( MorphismsOfExternalHom( T, Fv( b ) ), eta ->
+                                                               List( ExactCoverWithGlobalElements( H, Fv( b ) ), eta ->
                                                                      PreCompose( H,
                                                                              x, # eta_a(x), where
                                                                              ValuesOnAllObjects( # eta_a, where

--- a/gap/PreSheaves.gi
+++ b/gap/PreSheaves.gi
@@ -2434,7 +2434,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
         
     fi;
     
-    if IsFpCategory( B ) and HasRangeCategoryOfHomomorphismStructure( B ) then
+    if HasRangeCategoryOfHomomorphismStructure( B ) then
         
         ##
         AddIsReflexive( PSh,


### PR DESCRIPTION
to include the f.p. algebroids

needs

* Toposes v2022.11-03 and
* FinSetsForCAP v2022.11-05 (https://github.com/homalg-project/FinSetsForCAP/pull/150)