### PR TITLE
only_primitive_operations of Opposite in CoPreSheaves

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.11-29",
+Version := "2022.11-30",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/examples/TerminalCategory.g
+++ b/examples/TerminalCategory.g
@@ -8,7 +8,7 @@ T := FiniteCompletion( InitialCategory( ) );
 IsTerminalCategory( T );
 #! true
 InfoOfInstalledOperationsOfCategory( T );
-#! 423 primitive operations were used to derive 446 operations for this category
+#! 89 primitive operations were used to derive 449 operations for this category
 #! which algorithmically
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
@@ -63,7 +63,7 @@ IsWellDefined( z );
 id_z := IdentityMorphism( z );
 #! <A zero, identity morphism in FiniteCompletion( InitialCategory( ) )>
 fn_z := ZeroObjectFunctorial( T );
-#! <A morphism in FiniteCompletion( InitialCategory( ) )>
+#! <A zero, isomorphism in FiniteCompletion( InitialCategory( ) )>
 IsWellDefined( fn_z );
 #! true
 IsEqualForMorphisms( id_z, fn_z );

--- a/examples/notebooks/PastingLawForPullbacks.ipynb
+++ b/examples/notebooks/PastingLawForPullbacks.ipynb
@@ -225,7 +225,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "209 primitive operations were used to derive 230 operations for this category which algorithmically\n",
+      "65 primitive operations were used to derive 216 operations for this category which algorithmically\n",
       "* IsEquippedWithHomomorphismStructure\n",
       "* IsFiniteCocompleteCategory\n",
       "* IsFiniteCompleteCategory\n",

--- a/gap/CoPreSheaves.gi
+++ b/gap/CoPreSheaves.gi
@@ -443,7 +443,7 @@ InstallMethodWithCache( CoPreSheaves,
     
     Hom := FunctorCategory( B, C : FinalizeCategory := true );
     
-    O := Opposite( Hom : FinalizeCategory := true );
+    O := Opposite( Hom : FinalizeCategory := true, only_primitive_operations := true );
     
     ## from the raw object data to the object in the highest stage of the tower
     modeling_tower_object_constructor :=


### PR DESCRIPTION
as a consequence, these three extra operations were derived for TerminalCategory

```
[ "HomologyObjectFunctorialWithGivenHomologyObjects",
  "IsomorphismFromHomologyObjectToItsConstructionAsAnImageObject",
  "IsomorphismFromItsConstructionAsAnImageObjectToHomologyObject" ]
```