### PR TITLE
far better compilation of ExponentialOnObjects for FinQuivers 🎉

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.12-10",
+Version := "2022.12-12",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
@@ -92,7 +92,7 @@ Dependencies := rec(
                    [ "CAP", ">= 2022.12-01" ],
                    [ "MonoidalCategories", ">= 2022.06-04" ],
                    [ "CartesianCategories", ">= 2022.10-01" ],
-                   [ "Algebroids", ">= 2022.12-11" ],
+                   [ "Algebroids", ">= 2022.12-17" ],
                    [ "RingsForHomalg", ">= 2020.02.04" ],
                    [ "LinearAlgebraForCAP", ">= 2020.01.10" ],
                    [ "FreydCategoriesForCAP", ">= 2019.11.02" ],

--- a/examples/PrecompilePreSheavesInCategoryOfRows.g
+++ b/examples/PrecompilePreSheavesInCategoryOfRows.g
@@ -52,6 +52,7 @@ precompile_PreSheavesInCategoryOfRows :=
                       "MonomorphismIntoInjectiveEnvelopeObject",
                       "IndecomposableProjectiveObjects",
                       "IndecomposableInjectiveObjects",
+                      "IsReflexive",
                       ] ) ); end;;
 
 precompile_PreSheavesInCategoryOfRows( A, "PreSheavesOfFreeAlgebroidInCategoryOfRowsPrecompiled" );

--- a/gap/CategoryOfQuivers.gi
+++ b/gap/CategoryOfQuivers.gi
@@ -62,10 +62,10 @@ BindGlobal( "DefiningPairOfUnderlyingQuiverOfCategoryOfQuivers",
 #                       [ 0, 3 ],
 #                       [ 0, 0, 0, 1 ],
 #                       [ 0, 1, 1, 1 ],
-#                       [ [ 0, 1, 2, fail ],
-#                         [ fail, fail, fail, 1 ],
-#                         [ fail, fail, fail, 2 ],
-#                         [ fail, fail, fail, 3 ] ],
+#                       [ [ 0, 1, 2, -1 ],
+#                         [ -1, -1, -1, 1 ],
+#                         [ -1, -1, -1, 2 ],
+#                         [ -1, -1, -1, 3 ] ],
 #                       [ [ 1, 2 ],
 #                         [ 0, 1 ] ],
 #                       [ [ [ 0 ], [ 0 ], [ 1 ], [ 0, 1 ] ],
@@ -156,22 +156,22 @@ rec(
                                   type := "EXPR_INT",
                                   value := 2 ),
                               4 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               length := 4,
                               type := "SYNTAX_TREE_LIST" ),
                           type := "EXPR_LIST" ),
                       2 := rec(
                           list := rec(
                               1 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               2 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               3 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               4 := rec(
                                   type := "EXPR_INT",
                                   value := 1 ),
@@ -181,14 +181,14 @@ rec(
                       3 := rec(
                           list := rec(
                               1 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               2 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               3 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               4 := rec(
                                   type := "EXPR_INT",
                                   value := 2 ),
@@ -198,14 +198,14 @@ rec(
                       4 := rec(
                           list := rec(
                               1 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               2 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               3 := rec(
-                                  gvar := "fail",
-                                  type := "EXPR_REF_GVAR" ),
+                                  type := "EXPR_INT",
+                                  value := -1 ),
                               4 := rec(
                                   type := "EXPR_INT",
                                   value := 3 ),

--- a/gap/CategoryOfQuivers.gi
+++ b/gap/CategoryOfQuivers.gi
@@ -9,7 +9,7 @@ BindGlobal( "QuiverOfCategoryOfQuivers",
         RightQuiver( "q(V,A)[s:V->A,t:V->A]" ) );
 
 # Display( ENHANCED_SYNTAX_TREE( x -> Pair( 2, [ Pair( 0, 1 ), Pair( 0, 1 ) ] ) ).bindings.BINDING_RETURN_VALUE );
-BindGlobal( "DefiningPairOfUnderlyingQuiverOfCategoryOfQuivers",
+BindGlobal( "ENHANCED_SYNTAX_TREE_DefiningPairOfUnderlyingQuiverOfCategoryOfQuivers",
         rec( args :=
              rec(
                  1 := rec(
@@ -75,7 +75,7 @@ BindGlobal( "DefiningPairOfUnderlyingQuiverOfCategoryOfQuivers",
 #                       [ [ 0 ], [ 0 ], [ 1 ], [ 0 ] ],
 #                       [ [ [ 0 ], [ 1, 2 ] ],
 #                         [ [  ], [ 3 ] ] ] ) ) ).bindings.BINDING_RETURN_VALUE );
-BindGlobal( "DataTablesOfCategoryOfQuivers",
+BindGlobal( "ENHANCED_SYNTAX_TREE_DataTablesOfCategoryOfQuivers",
 rec(
   args := rec(
       1 := rec(
@@ -470,7 +470,7 @@ rec(
 );
 
 # Display( ENHANCED_SYNTAX_TREE( x -> [ 1, 2 ] ).bindings.BINDING_RETURN_VALUE );
-BindGlobal( "IndicesOfGeneratingMorphismsOfCategoryOfQuivers",
+BindGlobal( "ENHANCED_SYNTAX_TREE_IndicesOfGeneratingMorphismsOfCategoryOfQuivers",
 rec(
   list := rec(
       1 := rec(
@@ -581,11 +581,13 @@ InstallMethodWithCache( CategoryOfQuiversEnrichedOver,
                  : FinalizeCategory := true );
     
     F_hat := FiniteCocompletion( F, category_of_skeletal_finsets : FinalizeCategory := true );
-    
-    ModelingCategory( F_hat )!.compiler_hints.category_attribute_resolving_functions :=
-      rec( DefiningPairOfUnderlyingQuiver := { } -> DefiningPairOfUnderlyingQuiverOfCategoryOfQuivers,
-           DataTablesOfCategory := { } -> DataTablesOfCategoryOfQuivers,
-           IndicesOfGeneratingMorphisms := { } -> IndicesOfGeneratingMorphismsOfCategoryOfQuivers );
+
+    ## specify the attributes the compiler should fully resolve during compilation
+    F!.compiler_hints.category_attribute_resolving_functions :=
+      rec( DefiningPairOfUnderlyingQuiver := { } -> ENHANCED_SYNTAX_TREE_DefiningPairOfUnderlyingQuiverOfCategoryOfQuivers,
+           DataTablesOfCategory := { } -> ENHANCED_SYNTAX_TREE_DataTablesOfCategoryOfQuivers,
+           IndicesOfGeneratingMorphisms := { } -> ENHANCED_SYNTAX_TREE_IndicesOfGeneratingMorphismsOfCategoryOfQuivers,
+           );
     
     ## from the raw object data to the object in the highest stage of the tower
     modeling_tower_object_constructor :=

--- a/gap/CoPreSheaves.gi
+++ b/gap/CoPreSheaves.gi
@@ -183,7 +183,7 @@ InstallMethodForCompilerForCAP( CreateCoPreSheafByFunctions,
   function ( coPSh, copresheaf_on_objects, copresheaf_on_generating_morphisms )
     local defining_pair, nr_objs, mors, nr_mors, values_of_all_objects, values_of_all_generating_morphisms;
     
-    defining_pair := DefiningPairOfUnderlyingQuiver( coPSh );
+    defining_pair := DefiningPairOfUnderlyingQuiver( Source( coPSh ) );
     
     nr_objs := defining_pair[1];
     mors := defining_pair[2];
@@ -330,7 +330,7 @@ InstallOtherMethodForCompilerForCAP( CreateCoPreSheafMorphism,
   function ( coPSh, source, natural_transformation_on_objects, range )
     local nr_objs, source_values, range_values, values_on_all_objects;
     
-    nr_objs := DefiningPairOfUnderlyingQuiver( coPSh )[1];
+    nr_objs := DefiningPairOfUnderlyingQuiver( Source( coPSh ) )[1];
     
     source_values := ValuesOfCoPreSheaf( source )[1];
     range_values := ValuesOfCoPreSheaf( range )[1];
@@ -422,7 +422,7 @@ InstallMethodWithCache( CoPreSheaves,
   function( B, C )
     local object_constructor, object_datum,
           morphism_constructor, morphism_datum,
-          defining_pair, Hom, O,
+          Hom, O,
           modeling_tower_object_constructor, modeling_tower_object_datum,
           modeling_tower_morphism_constructor, modeling_tower_morphism_datum,
           coPSh, properties, name;
@@ -532,15 +532,12 @@ InstallMethodWithCache( CoPreSheaves,
     SetSetOfObjects( coPSh, SetOfObjects( B ) );
     SetSetOfGeneratingMorphisms( coPSh, SetOfGeneratingMorphisms( B ) );
     
-    SetDefiningPairOfUnderlyingQuiver( coPSh, DefiningPairOfUnderlyingQuiver( Hom ) );
-    
     coPSh!.compiler_hints.category_attribute_names :=
       [ "ModelingCategory",
         "Source",
         "Range",
         "SetOfObjects",
         "SetOfGeneratingMorphisms",
-        "DefiningPairOfUnderlyingQuiver",
         ];
     
     Finalize( coPSh );

--- a/gap/CompilerLogic.gi
+++ b/gap/CompilerLogic.gi
@@ -87,6 +87,14 @@ CapJitAddLogicTemplate(
 CapJitAddLogicTemplate(
     rec(
         variable_names := [ ],
+        src_template := "Sum( [ ] )",
+        dst_template := "0",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ ],
         src_template := "Product( [ ] )",
         dst_template := "1",
     )
@@ -97,6 +105,38 @@ CapJitAddLogicTemplate(
         variable_names := [ "entry" ],
         src_template := "Product( [ entry ] )",
         dst_template := "entry",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number" ],
+        src_template := "Product( [ number, 1, 1, 1 ] )",
+        dst_template := "number",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number" ],
+        src_template := "Product( [ number, number, number ] )",
+        dst_template := "number ^ 3",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number1", "number2", "number3" ],
+        src_template := "Product( [ number1, number2, number3 ] )",
+        dst_template := "number1 * number2 * number3",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number1", "number2", "number3", "number4" ],
+        src_template := "Product( [ number1, number2, number3, number4 ] )",
+        dst_template := "number1 * number2 * number3 * number4",
     )
 );
 
@@ -121,6 +161,14 @@ CapJitAddLogicTemplate(
         variable_names := [ "value1", "value2" ],
         src_template := "Sum( [ value1, value2 ] )",
         dst_template := "value1 + value2",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number" ],
+        src_template := "number ^ 0",
+        dst_template := "1",
     )
 );
 

--- a/gap/FunctorCategories.gi
+++ b/gap/FunctorCategories.gi
@@ -183,7 +183,7 @@ InstallMethodForCompilerForCAP( AsObjectInFunctorCategoryByFunctions,
   function ( Hom, functor_on_objects, functor_on_generating_morphisms )
     local defining_pair, nr_objs, mors, nr_mors, values_of_all_objects, values_of_all_generating_morphisms;
     
-    defining_pair := DefiningPairOfUnderlyingQuiver( Hom );
+    defining_pair := DefiningPairOfUnderlyingQuiver( Source( Hom ) );
     
     nr_objs := defining_pair[1];
     mors := defining_pair[2];
@@ -330,7 +330,7 @@ InstallOtherMethodForCompilerForCAP( AsMorphismInFunctorCategory,
   function ( Hom, source, natural_transformation_on_objects, range )
     local nr_objs, source_values, range_values, values_on_all_objects;
     
-    nr_objs := DefiningPairOfUnderlyingQuiver( Hom )[1];
+    nr_objs := DefiningPairOfUnderlyingQuiver( Source( Hom ) )[1];
     
     source_values := ValuesOfFunctor( source )[1];
     range_values := ValuesOfFunctor( range )[1];
@@ -443,22 +443,16 @@ InstallMethodWithCache( FunctorCategory,
     
     if IsFpCategory( B ) then
         B_op := OppositeFpCategory( B : FinalizeCategory := true );
-        defining_pair := DefiningPairOfUnderlyingQuiver( B_op );
     elif IsCategoryFromNerveData( B ) then
         B_op := OppositeCategoryFromNerveData( B : FinalizeCategory := true );
-        defining_pair := DefiningPairOfUnderlyingQuiver( B_op );
     elif IsCategoryFromDataTables( B ) then
         B_op := OppositeCategoryFromDataTables( B : FinalizeCategory := true );
-        defining_pair := DefiningPairOfUnderlyingQuiver( B_op );
     elif HasIsFinite( B ) and IsFinite( B ) then
         B_op := OppositeFiniteCategory( B : FinalizeCategory := true );
-        defining_pair := DefiningPairOfUnderlyingQuiver( B_op );
     elif IsAlgebroid( B ) then
         B_op := OppositeAlgebroid( B : FinalizeCategory := true );
-        defining_pair := DefiningPairOfUnderlyingQuiver( B_op );
     elif HasIsInitialCategory( B ) and IsInitialCategory( B ) then
         B_op := Opposite( B : FinalizeCategory := true );
-        defining_pair := Pair( 0, [ ] );
     else
         Error( "the first argument must be in { IsFpCategory, IsCategoryFromNerveData, IsCategoryFromDataTables, IsFinite, IsInitialCategory, IsAlgebroid }\n" );
     fi;
@@ -664,8 +658,6 @@ InstallMethodWithCache( FunctorCategory,
     SetSetOfObjects( Hom, SetOfObjects( B ) );
     SetSetOfGeneratingMorphisms( Hom, SetOfGeneratingMorphisms( B ) );
     
-    SetDefiningPairOfUnderlyingQuiver( Hom, defining_pair );
-    
     SetOppositeOfSource( Hom, B_op );
     
     Hom!.compiler_hints.category_attribute_names :=
@@ -675,7 +667,6 @@ InstallMethodWithCache( FunctorCategory,
         "SetOfObjects",
         "SetOfGeneratingMorphisms",
         "OppositeOfSource",
-        "DefiningPairOfUnderlyingQuiver",
         ];
     
     Finalize( Hom );

--- a/gap/Functors.gi
+++ b/gap/Functors.gi
@@ -392,7 +392,7 @@ InstallMethodForCompilerForCAP( UnitOfIsbellAdjunctionData,
     H := Range( PSh );
     
     objs := SetOfObjects( B );
-    nr_objs := DefiningPairOfUnderlyingQuiver( PSh )[1];
+    nr_objs := DefiningPairOfUnderlyingQuiver( B )[1];
     
     O := IsbellLeftAdjointData( PSh, coPSh )[1];
     

--- a/gap/HomStructure.gi
+++ b/gap/HomStructure.gi
@@ -12,7 +12,7 @@ InstallMethodForCompilerForCAP( ExternalHomDiagram,
     local defining_pair, nr_o, F_o, G_o, C, sources,
           mors, nr_m, F_m, G_m, mor_pair, morphisms, objects;
     
-    defining_pair := DefiningPairOfUnderlyingQuiver( PSh );
+    defining_pair := DefiningPairOfUnderlyingQuiver( Source( PSh ) );
     
     nr_o := defining_pair[1];
     

--- a/gap/HomologicalMethods.gi
+++ b/gap/HomologicalMethods.gi
@@ -20,7 +20,7 @@ InstallOtherMethodForCompilerForCAP( RadicalInclusionOfPreSheaf,
     
     vals_F := ValuesOfPreSheaf( F );
     
-    def_pair := DefiningPairOfUnderlyingQuiver( PSh );
+    def_pair := DefiningPairOfUnderlyingQuiver( Source( PSh ) );
     
     pos := List( [ 0 .. def_pair[1] - 1 ], i -> Positions( List( def_pair[2], r -> r[1] ), i ) );
     

--- a/gap/PreSheaves.gi
+++ b/gap/PreSheaves.gi
@@ -769,7 +769,7 @@ InstallMethodForCompilerForCAP( CreatePreSheafByFunctions,
   function ( PSh, presheaf_on_objects, presheaf_on_generating_morphisms )
     local defining_pair, nr_objs, mors, nr_mors, values_of_all_objects, values_of_all_generating_morphisms;
     
-    defining_pair := DefiningPairOfUnderlyingQuiver( PSh );
+    defining_pair := DefiningPairOfUnderlyingQuiver( Source( PSh ) );
     
     nr_objs := defining_pair[1];
     mors := defining_pair[2];
@@ -932,7 +932,7 @@ InstallOtherMethodForCompilerForCAP( CreatePreSheafMorphismByFunction,
   function ( PSh, source, natural_transformation_on_objects, range )
     local nr_objs, source_values, range_values, values_on_all_objects;
     
-    nr_objs := DefiningPairOfUnderlyingQuiver( PSh )[1];
+    nr_objs := DefiningPairOfUnderlyingQuiver( Source( PSh ) )[1];
     
     source_values := ValuesOfPreSheaf( source )[1];
     range_values := ValuesOfPreSheaf( range )[1];
@@ -1192,7 +1192,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
                 
                 presheaf_on_objects := objB_index -> operation_name( C, List( etas, eta -> ValuesOnAllObjects( eta )[objB_index] ) );
                 
-                mors := DefiningPairOfUnderlyingQuiver( cat )[2];
+                mors := DefiningPairOfUnderlyingQuiver( Source( cat ) )[2];
                 
                 presheaf_on_morphisms :=
                   function ( new_source, morB_index, new_range )
@@ -1239,7 +1239,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
                 
                 presheaf_on_objects := objB_index -> operation_name( C, List( etas, eta -> ValuesOnAllObjects( eta )[objB_index] ) );
                 
-                mors := DefiningPairOfUnderlyingQuiver( cat )[2];
+                mors := DefiningPairOfUnderlyingQuiver( Source( cat ) )[2];
                 
                 presheaf_on_morphisms :=
                   function ( new_source, morB_index, new_range )
@@ -1315,7 +1315,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
                 
                 presheaf_on_objects := objB_index -> operation_name( C, ValuesOnAllObjects( eta )[objB_index] );
                 
-                mors := DefiningPairOfUnderlyingQuiver( cat )[2];
+                mors := DefiningPairOfUnderlyingQuiver( Source( cat ) )[2];
                 
                 presheaf_on_morphisms :=
                   function ( new_source, morB_index, new_range )
@@ -1488,8 +1488,6 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
     SetSetOfObjects( PSh, objects );
     SetSetOfGeneratingMorphisms( PSh, generating_morphisms );
     
-    SetDefiningPairOfUnderlyingQuiver( PSh, DefiningPairOfUnderlyingQuiver( B ) );
-    
     SetSource( PSh, B );
     SetRange( PSh, C );
     SetOppositeOfSource( PSh, B_op );
@@ -1500,7 +1498,6 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
         "SetOfObjects",
         "SetOfGeneratingMorphisms",
         "OppositeOfSource",
-        "DefiningPairOfUnderlyingQuiver",
         ];
     
     ## setting the cache comparison to IsIdenticalObj
@@ -1753,7 +1750,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
                 
                 H := RangeCategoryOfHomomorphismStructure( PSh );
                 
-                nr_objs := DefiningPairOfUnderlyingQuiver( PSh )[1];
+                nr_objs := DefiningPairOfUnderlyingQuiver( Source( PSh ) )[1];
                 
                 hom_diagram_source := ExternalHomDiagram( PSh, Range( eta ), Source( rho ) );
                 
@@ -1832,7 +1829,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
                               hom_diagram[1],
                               hom_diagram[2] );
                 
-                nr_objs := DefiningPairOfUnderlyingQuiver( PSh )[1];
+                nr_objs := DefiningPairOfUnderlyingQuiver( Source( PSh ) )[1];
                 
                 prjs := List( [ 0 .. nr_objs - 1 ],
                               i -> ProjectionInFactorOfLimit( H,
@@ -1866,7 +1863,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
                 
                 hom_diagram := ExternalHomDiagram( PSh, F, G );
                 
-                nr_objs := DefiningPairOfUnderlyingQuiver( PSh )[1];
+                nr_objs := DefiningPairOfUnderlyingQuiver( Source( PSh ) )[1];
                 
                 etas := List( [ 0 .. nr_objs - 1 ],
                               i -> PreCompose( H,
@@ -3368,22 +3365,21 @@ end );
 InstallMethod( SimpleObjects,
         [ IsPreSheafCategory ],
   function ( PSh )
-    local B, C, def_pair, obj_vals, mor_vals, simple_objs, i;
+    local C, defining_pair, obj_vals, mor_vals, simple_objs, i;
     
-    B := Source( PSh );
     C := Range( PSh );
     
-    def_pair := DefiningPairOfUnderlyingQuiver( PSh );
+    defining_pair := DefiningPairOfUnderlyingQuiver( Source( PSh ) );
     
     simple_objs := [ ];
     
-    for i in [ 1 .. def_pair[1] ] do
+    for i in [ 1 .. defining_pair[1] ] do
       
-      obj_vals := ListWithIdenticalEntries( def_pair[1], ZeroObject( C ) );
+      obj_vals := ListWithIdenticalEntries( defining_pair[1], ZeroObject( C ) );
       
       obj_vals[i] := TensorUnit( C );
       
-      mor_vals := List( def_pair[2], r -> ZeroMorphism( C, obj_vals[r[2]], obj_vals[r[1]] ) );
+      mor_vals := List( defining_pair[2], r -> ZeroMorphism( C, obj_vals[r[2]], obj_vals[r[1]] ) );
       
       simple_objs[i] := CreatePreSheafByValues( PSh, obj_vals, mor_vals );
       

--- a/gap/precompiled_categories/FinQuiversAsCCCPrecompiled.gi
+++ b/gap/precompiled_categories/FinQuiversAsCCCPrecompiled.gi
@@ -10,778 +10,146 @@ BindGlobal( "ADD_FUNCTIONS_FOR_FinQuiversAsCCCPrecompiled", function ( cat )
         
 ########
 function ( cat_1, a_1, b_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, hoisted_35_1, hoisted_36_1, hoisted_37_1, hoisted_38_1, hoisted_39_1, hoisted_40_1, hoisted_41_1, hoisted_42_1, hoisted_43_1, hoisted_44_1, hoisted_45_1, hoisted_46_1, hoisted_47_1, hoisted_48_1, hoisted_49_1, hoisted_50_1, 
-    hoisted_51_1, hoisted_52_1, hoisted_53_1, hoisted_54_1, hoisted_55_1, hoisted_56_1, hoisted_57_1, hoisted_58_1, hoisted_59_1, hoisted_60_1, hoisted_61_1, hoisted_62_1, hoisted_63_1, hoisted_64_1, hoisted_65_1, hoisted_66_1, hoisted_67_1, hoisted_68_1, hoisted_69_1, hoisted_70_1, hoisted_71_1, hoisted_72_1, hoisted_73_1, hoisted_74_1, hoisted_75_1, hoisted_76_1, hoisted_77_1, hoisted_78_1, hoisted_79_1, hoisted_80_1, hoisted_81_1, hoisted_82_1, hoisted_83_1, hoisted_84_1, hoisted_85_1, hoisted_86_1, hoisted_87_1, hoisted_88_1, hoisted_89_1, hoisted_90_1, hoisted_91_1, hoisted_92_1, hoisted_93_1, hoisted_94_1, hoisted_95_1, hoisted_96_1, hoisted_97_1, hoisted_98_1, hoisted_99_1, hoisted_100_1, hoisted_101_1, hoisted_102_1, hoisted_103_1, hoisted_104_1, hoisted_105_1, hoisted_106_1, hoisted_107_1, hoisted_108_1, hoisted_109_1, hoisted_110_1, hoisted_111_1, hoisted_112_1, hoisted_113_1, hoisted_114_1, hoisted_115_1, hoisted_116_1, hoisted_117_1, hoisted_118_1, hoisted_119_1, hoisted_120_1, hoisted_121_1, hoisted_122_1, hoisted_123_1, hoisted_124_1, hoisted_125_1, hoisted_126_1, hoisted_127_1, hoisted_128_1, hoisted_129_1, hoisted_130_1, hoisted_131_1, hoisted_132_1, hoisted_133_1, hoisted_134_1, hoisted_135_1, hoisted_136_1, hoisted_137_1, hoisted_138_1, hoisted_139_1, hoisted_140_1, hoisted_141_1, hoisted_142_1, hoisted_143_1, hoisted_144_1, hoisted_145_1, hoisted_146_1, hoisted_147_1, hoisted_148_1, hoisted_149_1, hoisted_150_1, hoisted_151_1, hoisted_152_1, hoisted_153_1, hoisted_154_1, hoisted_155_1, hoisted_156_1, hoisted_157_1, hoisted_158_1, hoisted_159_1, hoisted_160_1, hoisted_161_1, hoisted_162_1, hoisted_163_1, hoisted_164_1, hoisted_165_1, hoisted_166_1, hoisted_167_1, hoisted_168_1, hoisted_169_1, hoisted_170_1, hoisted_171_1, hoisted_172_1, hoisted_173_1, hoisted_174_1, hoisted_175_1, hoisted_176_1, hoisted_177_1, hoisted_178_1, hoisted_179_1, hoisted_180_1, hoisted_181_1, hoisted_182_1, hoisted_183_1, hoisted_184_1, hoisted_185_1, hoisted_186_1, hoisted_187_1, hoisted_188_1, hoisted_189_1, hoisted_190_1, hoisted_191_1, hoisted_192_1, hoisted_193_1, hoisted_194_1, hoisted_195_1, hoisted_196_1, hoisted_197_1, hoisted_198_1, hoisted_199_1, hoisted_200_1, hoisted_201_1, hoisted_202_1, hoisted_203_1, hoisted_204_1, hoisted_205_1, hoisted_206_1, hoisted_207_1, hoisted_208_1, hoisted_209_1, hoisted_210_1, hoisted_211_1, hoisted_212_1, hoisted_213_1, hoisted_214_1, hoisted_215_1, deduped_216_1, deduped_217_1, deduped_218_1, deduped_219_1, deduped_220_1, deduped_221_1, deduped_222_1, deduped_223_1, deduped_224_1, deduped_225_1, deduped_226_1, deduped_227_1, deduped_228_1, deduped_229_1, deduped_230_1, deduped_231_1, deduped_232_1, deduped_233_1, deduped_234_1, deduped_235_1, deduped_236_1, deduped_237_1, deduped_238_1, deduped_239_1, deduped_240_1, deduped_241_1, deduped_242_1, deduped_243_1, deduped_244_1, deduped_245_1, deduped_246_1, deduped_247_1, deduped_248_1, deduped_249_1, deduped_250_1, deduped_251_1, deduped_252_1, deduped_253_1, deduped_254_1, deduped_255_1, deduped_256_1, deduped_257_1, deduped_258_1, deduped_259_1, deduped_260_1, deduped_261_1, deduped_262_1, deduped_263_1, deduped_264_1, deduped_265_1, deduped_266_1, deduped_267_1, deduped_268_1, deduped_269_1, deduped_270_1, deduped_271_1, deduped_272_1, deduped_273_1, deduped_274_1, deduped_275_1, deduped_276_1, deduped_277_1, deduped_278_1, deduped_279_1, deduped_280_1, deduped_281_1, deduped_282_1, deduped_283_1, deduped_284_1, deduped_285_1, deduped_286_1, deduped_287_1, deduped_288_1, deduped_289_1, deduped_290_1, deduped_291_1, deduped_292_1, deduped_293_1, deduped_294_1, deduped_295_1, deduped_296_1, deduped_297_1, deduped_298_1, deduped_299_1, deduped_300_1, deduped_301_1, deduped_302_1, deduped_303_1, deduped_304_1, deduped_305_1, deduped_306_1, deduped_307_1, deduped_308_1, deduped_309_1, deduped_310_1, deduped_311_1, deduped_312_1, deduped_313_1, deduped_314_1, deduped_315_1, deduped_316_1, deduped_317_1, deduped_318_1, deduped_319_1, deduped_320_1, deduped_321_1, deduped_322_1, deduped_323_1, deduped_324_1, deduped_325_1, 
-    deduped_326_1, deduped_327_1, deduped_328_1, deduped_329_1, deduped_330_1, deduped_331_1, deduped_332_1, deduped_333_1, deduped_334_1, deduped_335_1, deduped_336_1, deduped_337_1, deduped_338_1, deduped_339_1, deduped_340_1, deduped_341_1, deduped_342_1, deduped_343_1, deduped_344_1, deduped_345_1, deduped_346_1, deduped_347_1, deduped_348_1, deduped_349_1, deduped_350_1, deduped_351_1, deduped_352_1;
-    deduped_352_1 := DefiningTripleOfQuiver( a_1 );
-    deduped_351_1 := DefiningTripleOfQuiver( b_1 );
-    deduped_350_1 := deduped_351_1[3];
-    deduped_349_1 := deduped_352_1[3];
-    deduped_348_1 := deduped_352_1[2];
-    deduped_347_1 := deduped_351_1[2];
-    deduped_346_1 := deduped_352_1[1];
-    deduped_345_1 := deduped_351_1[1];
-    deduped_344_1 := Source( ModelingCategory( ModelingCategory( cat_1 ) ) );
-    deduped_343_1 := IndicesOfGeneratingMorphisms( deduped_344_1 );
-    deduped_342_1 := DataTablesOfCategory( deduped_344_1 );
-    deduped_337_1 := deduped_342_1[1];
-    deduped_335_1 := [ 0 .. deduped_337_1[2] - 1 ];
-    deduped_315_1 := List( deduped_335_1, function ( logic_new_func_x_2 )
-            return [ logic_new_func_x_2 ];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, hoisted_35_1, hoisted_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1, deduped_64_1;
+    deduped_64_1 := DefiningTripleOfQuiver( a_1 );
+    deduped_63_1 := DefiningTripleOfQuiver( b_1 );
+    deduped_62_1 := deduped_63_1[3];
+    deduped_61_1 := deduped_64_1[3];
+    deduped_60_1 := deduped_64_1[2];
+    deduped_59_1 := deduped_63_1[2];
+    deduped_58_1 := deduped_64_1[1];
+    deduped_57_1 := deduped_63_1[1];
+    deduped_56_1 := deduped_57_1 ^ deduped_60_1;
+    deduped_55_1 := deduped_59_1 ^ deduped_60_1;
+    deduped_54_1 := 2 * deduped_58_1;
+    deduped_53_1 := deduped_57_1 ^ deduped_58_1;
+    deduped_52_1 := [ 0 .. deduped_58_1 - 1 ];
+    deduped_51_1 := [ 0 .. deduped_60_1 - 1 ];
+    deduped_50_1 := deduped_56_1 * deduped_56_1;
+    deduped_49_1 := deduped_57_1 ^ deduped_54_1;
+    deduped_48_1 := [ 0 .. deduped_55_1 - 1 ];
+    deduped_47_1 := [ 0 .. deduped_53_1 - 1 ];
+    deduped_46_1 := deduped_49_1 * deduped_55_1;
+    deduped_45_1 := [ 0 .. deduped_49_1 - 1 ];
+    deduped_44_1 := Filtered( deduped_47_1, function ( x_2 )
+            return true;
         end );
-    hoisted_9_1 := deduped_315_1;
-    deduped_341_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_9_1[1 + logic_new_func_x_2];
-        end );
-    deduped_338_1 := deduped_342_1[2];
-    hoisted_6_1 := deduped_338_1[2];
-    deduped_314_1 := List( deduped_335_1, function ( logic_new_func_x_2 )
-            return [ hoisted_6_1[1 + logic_new_func_x_2] ];
-        end );
-    hoisted_8_1 := deduped_314_1;
-    deduped_340_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_8_1[1 + logic_new_func_x_2];
-        end );
-    hoisted_4_1 := deduped_338_1[3];
-    deduped_313_1 := List( deduped_335_1, function ( logic_new_func_x_2 )
-            return [ hoisted_4_1[1 + logic_new_func_x_2] ];
-        end );
-    hoisted_5_1 := deduped_313_1;
-    deduped_339_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_5_1[1 + logic_new_func_x_2];
-        end );
-    deduped_336_1 := deduped_338_1[1];
-    deduped_334_1 := [ 0 .. deduped_337_1[1] - 1 ];
-    deduped_330_1 := 1 + deduped_340_1[2][1];
-    deduped_301_1 := 1 + deduped_336_1[deduped_330_1];
-    hoisted_183_1 := 1 + deduped_313_1[deduped_301_1][1];
-    hoisted_1_1 := deduped_338_1[5];
-    deduped_333_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_8_1[(1 + logic_new_func_x_2)][1]][hoisted_183_1];
-        end );
-    hoisted_176_1 := 1 + deduped_315_1[deduped_301_1][1];
-    hoisted_10_1 := deduped_338_1[6];
-    deduped_332_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_10_1[1 + hoisted_9_1[(1 + logic_new_func_x_2)][1]][hoisted_176_1];
-        end );
-    hoisted_177_1 := 1 + deduped_314_1[deduped_301_1][1];
-    deduped_331_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_5_1[(1 + logic_new_func_x_2)][1]][hoisted_177_1];
-        end );
-    deduped_326_1 := 1 + deduped_339_1[2][1];
-    deduped_300_1 := 1 + deduped_336_1[deduped_326_1];
-    hoisted_155_1 := 1 + deduped_313_1[deduped_300_1][1];
-    deduped_329_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_8_1[(1 + logic_new_func_x_2)][1]][hoisted_155_1];
-        end );
-    hoisted_148_1 := 1 + deduped_315_1[deduped_300_1][1];
-    deduped_328_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_10_1[1 + hoisted_9_1[(1 + logic_new_func_x_2)][1]][hoisted_148_1];
-        end );
-    hoisted_149_1 := 1 + deduped_314_1[deduped_300_1][1];
-    deduped_327_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_5_1[(1 + logic_new_func_x_2)][1]][hoisted_149_1];
-        end );
-    deduped_322_1 := 1 + deduped_340_1[1][1];
-    deduped_298_1 := 1 + deduped_336_1[deduped_322_1];
-    hoisted_106_1 := 1 + deduped_313_1[deduped_298_1][1];
-    deduped_325_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_8_1[(1 + logic_new_func_x_2)][1]][hoisted_106_1];
-        end );
-    hoisted_99_1 := 1 + deduped_315_1[deduped_298_1][1];
-    deduped_324_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_10_1[1 + hoisted_9_1[(1 + logic_new_func_x_2)][1]][hoisted_99_1];
-        end );
-    hoisted_100_1 := 1 + deduped_314_1[deduped_298_1][1];
-    deduped_323_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_5_1[(1 + logic_new_func_x_2)][1]][hoisted_100_1];
-        end );
-    deduped_318_1 := 1 + deduped_339_1[1][1];
-    deduped_297_1 := 1 + deduped_336_1[deduped_318_1];
-    hoisted_78_1 := 1 + deduped_313_1[deduped_297_1][1];
-    deduped_321_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_8_1[(1 + logic_new_func_x_2)][1]][hoisted_78_1];
-        end );
-    hoisted_71_1 := 1 + deduped_315_1[deduped_297_1][1];
-    deduped_320_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_10_1[1 + hoisted_9_1[(1 + logic_new_func_x_2)][1]][hoisted_71_1];
-        end );
-    hoisted_72_1 := 1 + deduped_314_1[deduped_297_1][1];
-    deduped_319_1 := List( deduped_343_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + hoisted_5_1[(1 + logic_new_func_x_2)][1]][hoisted_72_1];
-        end );
-    hoisted_168_1 := deduped_330_1;
-    deduped_317_1 := List( deduped_334_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + logic_new_func_x_2][hoisted_168_1];
-        end );
-    hoisted_91_1 := deduped_322_1;
-    deduped_316_1 := List( deduped_334_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + logic_new_func_x_2][hoisted_91_1];
-        end );
-    hoisted_140_1 := deduped_326_1;
-    deduped_312_1 := List( deduped_334_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + logic_new_func_x_2][hoisted_140_1];
-        end );
-    hoisted_63_1 := deduped_318_1;
-    deduped_311_1 := List( deduped_334_1, function ( logic_new_func_x_2 )
-            return hoisted_1_1[1 + logic_new_func_x_2][hoisted_63_1];
-        end );
-    deduped_310_1 := deduped_317_1[2];
-    deduped_309_1 := deduped_317_1[1];
-    deduped_308_1 := deduped_316_1[2];
-    deduped_307_1 := deduped_316_1[1];
-    deduped_306_1 := deduped_312_1[2];
-    deduped_305_1 := deduped_312_1[1];
-    deduped_304_1 := deduped_311_1[2];
-    deduped_303_1 := deduped_311_1[1];
-    hoisted_198_1 := 1 + deduped_341_1[2][1];
-    hoisted_7_1 := deduped_336_1;
-    deduped_302_1 := List( deduped_334_1, function ( logic_new_func_x_2 )
-            return hoisted_10_1[1 + hoisted_9_1[(1 + hoisted_7_1[(1 + logic_new_func_x_2)])][1]][hoisted_198_1];
-        end );
-    hoisted_121_1 := 1 + deduped_341_1[1][1];
-    deduped_299_1 := List( deduped_334_1, function ( logic_new_func_x_2 )
-            return hoisted_10_1[1 + hoisted_9_1[(1 + hoisted_7_1[(1 + logic_new_func_x_2)])][1]][hoisted_121_1];
-        end );
-    deduped_296_1 := deduped_310_1 * deduped_348_1;
-    deduped_295_1 := deduped_309_1 * deduped_346_1;
-    deduped_294_1 := deduped_308_1 * deduped_348_1;
-    deduped_293_1 := deduped_307_1 * deduped_346_1;
-    deduped_292_1 := deduped_306_1 * deduped_348_1;
-    deduped_291_1 := deduped_305_1 * deduped_346_1;
-    deduped_290_1 := deduped_304_1 * deduped_348_1;
-    deduped_289_1 := deduped_303_1 * deduped_346_1;
-    deduped_288_1 := deduped_345_1 ^ deduped_296_1;
-    deduped_287_1 := deduped_347_1 ^ deduped_296_1;
-    deduped_286_1 := deduped_345_1 ^ deduped_295_1;
-    deduped_285_1 := deduped_345_1 ^ deduped_294_1;
-    deduped_284_1 := deduped_347_1 ^ deduped_294_1;
-    deduped_283_1 := deduped_345_1 ^ deduped_293_1;
-    deduped_282_1 := deduped_345_1 ^ deduped_292_1;
-    deduped_281_1 := deduped_347_1 ^ deduped_292_1;
-    deduped_280_1 := deduped_345_1 ^ deduped_291_1;
-    deduped_279_1 := deduped_345_1 ^ deduped_290_1;
-    deduped_278_1 := deduped_347_1 ^ deduped_290_1;
-    deduped_277_1 := deduped_345_1 ^ deduped_289_1;
-    deduped_276_1 := [ 0 .. deduped_296_1 - 1 ];
-    deduped_275_1 := [ 0 .. deduped_295_1 - 1 ];
-    deduped_274_1 := [ 0 .. deduped_292_1 - 1 ];
-    deduped_273_1 := [ 0 .. deduped_294_1 - 1 ];
-    deduped_272_1 := [ 0 .. deduped_293_1 - 1 ];
-    deduped_271_1 := [ 0 .. deduped_290_1 - 1 ];
-    deduped_270_1 := deduped_280_1 * deduped_281_1;
-    deduped_269_1 := deduped_277_1 * deduped_278_1;
-    deduped_268_1 := [ 0 .. deduped_287_1 - 1 ];
-    deduped_267_1 := [ 0 .. deduped_286_1 - 1 ];
-    deduped_266_1 := [ 0 .. deduped_281_1 - 1 ];
-    deduped_265_1 := [ 0 .. deduped_280_1 - 1 ];
-    deduped_264_1 := [ 0 .. deduped_284_1 - 1 ];
-    deduped_263_1 := [ 0 .. deduped_283_1 - 1 ];
-    deduped_262_1 := [ 0 .. deduped_278_1 - 1 ];
-    deduped_261_1 := [ 0 .. deduped_277_1 - 1 ];
-    hoisted_11_1 := deduped_343_1;
-    hoisted_3_1 := deduped_334_1;
-    hoisted_2_1 := RangeCategoryOfHomomorphismStructure( cat_1 );
-    deduped_260_1 := List( deduped_334_1, function ( logic_new_func_x_2 )
-            local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2;
-            deduped_6_2 := 1 + logic_new_func_x_2;
-            deduped_5_2 := 1 + hoisted_7_1[deduped_6_2];
-            hoisted_4_2 := 1 + hoisted_9_1[deduped_5_2][1];
-            hoisted_3_2 := 1 + hoisted_5_1[deduped_5_2][1];
-            hoisted_2_2 := 1 + hoisted_8_1[deduped_5_2][1];
-            hoisted_1_2 := deduped_6_2;
-            return NTuple( 2, List( hoisted_3_1, function ( logic_new_func_x_3 )
-                      return CreateCapCategoryObjectWithAttributes( hoisted_2_1, Length, hoisted_1_1[1 + logic_new_func_x_3][hoisted_1_2] );
-                  end ), List( hoisted_11_1, function ( logic_new_func_x_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + logic_new_func_x_3;
-                      return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, CreateCapCategoryObjectWithAttributes( hoisted_2_1, Length, hoisted_1_1[1 + hoisted_5_1[deduped_1_3][1]][hoisted_2_2] ), CreateCapCategoryObjectWithAttributes( hoisted_2_1, Length, hoisted_1_1[1 + hoisted_8_1[deduped_1_3][1]][hoisted_3_2] ), AsList, hoisted_10_1[1 + hoisted_9_1[deduped_1_3][1]][hoisted_4_2] );
-                  end ) );
-        end );
-    deduped_259_1 := [ 0 .. deduped_270_1 - 1 ];
-    deduped_258_1 := [ 0 .. deduped_269_1 - 1 ];
-    deduped_257_1 := deduped_260_1[2];
-    deduped_256_1 := deduped_260_1[1];
-    deduped_255_1 := [ 0 .. Product( [ deduped_286_1, deduped_287_1, deduped_288_1, deduped_288_1 ] ) - 1 ];
-    deduped_254_1 := [ 0 .. Product( [ deduped_283_1, deduped_284_1, deduped_285_1, deduped_285_1 ] ) - 1 ];
-    deduped_253_1 := [ 0 .. Product( [ deduped_280_1, deduped_281_1, deduped_282_1, deduped_282_1 ] ) - 1 ];
-    deduped_252_1 := [ 0 .. Product( [ deduped_277_1, deduped_278_1, deduped_279_1, deduped_279_1 ] ) - 1 ];
-    deduped_251_1 := deduped_257_1[2];
-    deduped_250_1 := deduped_256_1[2];
-    hoisted_180_1 := deduped_276_1;
-    hoisted_39_1 := List( deduped_350_1, function ( a_2 )
+    deduped_43_1 := deduped_46_1 * deduped_56_1;
+    deduped_42_1 := [ 0 .. deduped_46_1 - 1 ];
+    deduped_41_1 := Length( deduped_44_1 );
+    deduped_40_1 := [ 0 .. deduped_43_1 * deduped_56_1 - 1 ];
+    hoisted_22_1 := List( deduped_62_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_29_1 := deduped_347_1;
-    hoisted_18_1 := deduped_345_1;
-    hoisted_195_1 := List( deduped_268_1, function ( i_2 )
-            return Sum( List( hoisted_180_1, function ( k_3 )
-                      return hoisted_39_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_180_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
+    hoisted_15_1 := deduped_59_1;
+    hoisted_11_1 := deduped_51_1;
+    hoisted_7_1 := deduped_57_1;
+    hoisted_23_1 := List( deduped_48_1, function ( i_2 )
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_22_1[(1 + REM_INT( QUO_INT( i_2, hoisted_15_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_15_1 ))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_193_1 := deduped_333_1[2];
-    hoisted_189_1 := deduped_331_1[2];
-    hoisted_35_1 := List( deduped_349_1, function ( a_2 )
+    hoisted_19_1 := List( deduped_61_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_23_1 := deduped_348_1;
-    hoisted_192_1 := List( deduped_276_1, function ( logic_new_func_x_2 )
-            return hoisted_35_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_189_1 ), hoisted_23_1 )];
+    hoisted_9_1 := deduped_60_1;
+    hoisted_20_1 := List( deduped_51_1, function ( logic_new_func_x_2 )
+            return hoisted_19_1[1 + REM_INT( logic_new_func_x_2, hoisted_9_1 )];
         end );
-    hoisted_190_1 := deduped_332_1[2];
-    hoisted_191_1 := List( deduped_276_1, function ( logic_new_func_x_2 )
-            return hoisted_190_1[1 + REM_INT( logic_new_func_x_2, hoisted_189_1 )];
-        end );
-    hoisted_175_1 := deduped_275_1;
-    hoisted_194_1 := List( deduped_267_1, function ( i_2 )
+    hoisted_8_1 := [ 0 .. deduped_54_1 - 1 ];
+    hoisted_21_1 := List( deduped_45_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_175_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
+            hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
                 end );
-            return Sum( List( hoisted_180_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_180_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_191_1[deduped_1_3] + hoisted_192_1[deduped_1_3] * hoisted_193_1))] * hoisted_18_1 ^ k_3;
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_1_2[(1 + (1 + hoisted_20_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))] * 2))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_30_1 := List( deduped_350_1, function ( a_2 )
+    hoisted_16_1 := List( deduped_62_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_188_1 := List( deduped_268_1, function ( i_2 )
-            return Sum( List( hoisted_180_1, function ( k_3 )
-                      return hoisted_30_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_180_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
+    hoisted_18_1 := List( deduped_48_1, function ( i_2 )
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_16_1[(1 + REM_INT( QUO_INT( i_2, hoisted_15_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_15_1 ))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_187_1 := deduped_287_1;
-    hoisted_184_1 := deduped_333_1[1];
-    hoisted_178_1 := deduped_331_1[1];
-    hoisted_24_1 := List( deduped_349_1, function ( a_2 )
+    hoisted_17_1 := deduped_55_1;
+    hoisted_10_1 := List( deduped_61_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_182_1 := List( deduped_276_1, function ( logic_new_func_x_2 )
-            return hoisted_24_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_178_1 ), hoisted_23_1 )];
+    hoisted_12_1 := List( deduped_51_1, function ( logic_new_func_x_2 )
+            return hoisted_10_1[1 + REM_INT( logic_new_func_x_2, hoisted_9_1 )];
         end );
-    hoisted_179_1 := deduped_332_1[1];
-    hoisted_181_1 := List( deduped_276_1, function ( logic_new_func_x_2 )
-            return hoisted_179_1[1 + REM_INT( logic_new_func_x_2, hoisted_178_1 )];
-        end );
-    hoisted_186_1 := List( deduped_267_1, function ( i_2 )
+    hoisted_14_1 := List( deduped_45_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_175_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
+            hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
                 end );
-            return Sum( List( hoisted_180_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_180_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_181_1[deduped_1_3] + hoisted_182_1[deduped_1_3] * hoisted_184_1))] * hoisted_18_1 ^ k_3;
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_12_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))] * 2)] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_185_1 := deduped_286_1;
-    hoisted_174_1 := Product( [ deduped_288_1, deduped_288_1, deduped_288_1 ] );
-    hoisted_173_1 := deduped_288_1 * deduped_288_1;
-    hoisted_172_1 := Product( [ deduped_286_1, deduped_287_1, deduped_288_1 ] );
-    hoisted_171_1 := deduped_288_1;
-    hoisted_170_1 := deduped_286_1 * deduped_287_1;
-    hoisted_169_1 := deduped_255_1;
-    deduped_249_1 := Filtered( deduped_255_1, function ( x_2 )
+    hoisted_13_1 := deduped_49_1;
+    hoisted_6_1 := deduped_50_1 * deduped_56_1;
+    hoisted_5_1 := deduped_50_1;
+    hoisted_4_1 := deduped_43_1;
+    hoisted_3_1 := deduped_56_1;
+    hoisted_2_1 := deduped_46_1;
+    hoisted_1_1 := deduped_40_1;
+    deduped_39_1 := Filtered( deduped_40_1, function ( x_2 )
             local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_169_1[1 + x_2] );
-            deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_185_1 );
-            deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_172_1 ), hoisted_171_1 );
-            deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_170_1 ), hoisted_171_1 );
-            deduped_1_2 := 1 + REM_INT( QUO_INT( deduped_5_2, hoisted_185_1 ), hoisted_187_1 );
-            return deduped_2_2 + deduped_2_2 * hoisted_171_1 + deduped_3_2 * hoisted_173_1 + deduped_3_2 * hoisted_174_1 = hoisted_186_1[deduped_4_2] + hoisted_188_1[deduped_1_2] * hoisted_171_1 + hoisted_194_1[deduped_4_2] * hoisted_173_1 + hoisted_195_1[deduped_1_2] * hoisted_174_1;
+            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + x_2] );
+            deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_13_1 );
+            deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_4_1 ), hoisted_3_1 );
+            deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_2_1 ), hoisted_3_1 );
+            deduped_1_2 := 1 + REM_INT( QUO_INT( deduped_5_2, hoisted_13_1 ), hoisted_17_1 );
+            return deduped_2_2 + deduped_2_2 * hoisted_3_1 + deduped_3_2 * hoisted_5_1 + deduped_3_2 * hoisted_6_1 = hoisted_14_1[deduped_4_2] + hoisted_18_1[deduped_1_2] * hoisted_3_1 + hoisted_21_1[deduped_4_2] * hoisted_5_1 + hoisted_23_1[deduped_1_2] * hoisted_6_1;
         end );
-    hoisted_103_1 := deduped_273_1;
-    hoisted_118_1 := List( deduped_264_1, function ( i_2 )
-            return Sum( List( hoisted_103_1, function ( k_3 )
-                      return hoisted_39_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_103_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
+    deduped_38_1 := Length( deduped_39_1 );
+    deduped_37_1 := [ 0 .. deduped_38_1 - 1 ];
+    hoisted_27_1 := deduped_58_1;
+    hoisted_29_1 := List( deduped_52_1, function ( logic_new_func_x_2 )
+            return REM_INT( logic_new_func_x_2, hoisted_27_1 );
         end );
-    hoisted_116_1 := deduped_325_1[2];
-    hoisted_112_1 := deduped_323_1[2];
-    hoisted_115_1 := List( deduped_273_1, function ( logic_new_func_x_2 )
-            return hoisted_35_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_112_1 ), hoisted_23_1 )];
-        end );
-    hoisted_113_1 := deduped_324_1[2];
-    hoisted_114_1 := List( deduped_273_1, function ( logic_new_func_x_2 )
-            return hoisted_113_1[1 + REM_INT( logic_new_func_x_2, hoisted_112_1 )];
-        end );
-    hoisted_98_1 := deduped_272_1;
-    hoisted_117_1 := List( deduped_263_1, function ( i_2 )
+    hoisted_28_1 := deduped_52_1;
+    hoisted_35_1 := List( deduped_45_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_98_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
+            hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
                 end );
-            return Sum( List( hoisted_103_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_103_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_114_1[deduped_1_3] + hoisted_115_1[deduped_1_3] * hoisted_116_1))] * hoisted_18_1 ^ k_3;
+            return Sum( List( hoisted_28_1, function ( k_3 )
+                      return hoisted_1_2[(1 + (1 + hoisted_29_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_28_1[(1 + k_3)] ))] * 2))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_111_1 := List( deduped_264_1, function ( i_2 )
-            return Sum( List( hoisted_103_1, function ( k_3 )
-                      return hoisted_30_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_103_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
+    hoisted_36_1 := List( deduped_42_1, function ( logic_new_func_x_2 )
+            return hoisted_35_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
         end );
-    hoisted_110_1 := deduped_284_1;
-    hoisted_107_1 := deduped_325_1[1];
-    hoisted_101_1 := deduped_323_1[1];
-    hoisted_105_1 := List( deduped_273_1, function ( logic_new_func_x_2 )
-            return hoisted_24_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_101_1 ), hoisted_23_1 )];
+    hoisted_26_1 := deduped_53_1;
+    hoisted_25_1 := deduped_47_1;
+    hoisted_24_1 := deduped_44_1;
+    hoisted_34_1 := List( [ 0 .. deduped_41_1 - 1 ], function ( i_2 )
+            return REM_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_25_1[1 + hoisted_24_1[(1 + i_2)]] ), hoisted_26_1 );
         end );
-    hoisted_102_1 := deduped_324_1[1];
-    hoisted_104_1 := List( deduped_273_1, function ( logic_new_func_x_2 )
-            return hoisted_102_1[1 + REM_INT( logic_new_func_x_2, hoisted_101_1 )];
-        end );
-    hoisted_109_1 := List( deduped_263_1, function ( i_2 )
+    hoisted_30_1 := List( deduped_45_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_98_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
+            hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
                 end );
-            return Sum( List( hoisted_103_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_103_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_104_1[deduped_1_3] + hoisted_105_1[deduped_1_3] * hoisted_107_1))] * hoisted_18_1 ^ k_3;
+            return Sum( List( hoisted_28_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_29_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_28_1[(1 + k_3)] ))] * 2)] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_108_1 := deduped_283_1;
-    hoisted_97_1 := Product( [ deduped_285_1, deduped_285_1, deduped_285_1 ] );
-    hoisted_96_1 := deduped_285_1 * deduped_285_1;
-    hoisted_95_1 := Product( [ deduped_283_1, deduped_284_1, deduped_285_1 ] );
-    hoisted_94_1 := deduped_285_1;
-    hoisted_93_1 := deduped_283_1 * deduped_284_1;
-    hoisted_92_1 := deduped_254_1;
-    deduped_248_1 := Filtered( deduped_254_1, function ( x_2 )
-            local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_92_1[1 + x_2] );
-            deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_108_1 );
-            deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_95_1 ), hoisted_94_1 );
-            deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_93_1 ), hoisted_94_1 );
-            deduped_1_2 := 1 + REM_INT( QUO_INT( deduped_5_2, hoisted_108_1 ), hoisted_110_1 );
-            return deduped_2_2 + deduped_2_2 * hoisted_94_1 + deduped_3_2 * hoisted_96_1 + deduped_3_2 * hoisted_97_1 = hoisted_109_1[deduped_4_2] + hoisted_111_1[deduped_1_2] * hoisted_94_1 + hoisted_117_1[deduped_4_2] * hoisted_96_1 + hoisted_118_1[deduped_1_2] * hoisted_97_1;
+    hoisted_33_1 := List( deduped_42_1, function ( logic_new_func_x_2 )
+            return hoisted_30_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
         end );
-    deduped_247_1 := List( deduped_251_1, function ( logic_new_func_x_2 )
-            return Length( Range( logic_new_func_x_2 ) );
-        end );
-    deduped_246_1 := List( deduped_251_1, AsList );
-    deduped_245_1 := List( deduped_251_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
-        end );
-    deduped_244_1 := List( deduped_250_1, function ( logic_new_func_x_2 )
-            return Length( Range( logic_new_func_x_2 ) );
-        end );
-    deduped_243_1 := List( deduped_250_1, AsList );
-    deduped_242_1 := List( deduped_250_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
-        end );
-    hoisted_152_1 := deduped_274_1;
-    hoisted_167_1 := List( deduped_266_1, function ( i_2 )
-            return Sum( List( hoisted_152_1, function ( k_3 )
-                      return hoisted_39_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_152_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_165_1 := deduped_329_1[2];
-    hoisted_161_1 := deduped_327_1[2];
-    hoisted_164_1 := List( deduped_274_1, function ( logic_new_func_x_2 )
-            return hoisted_35_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_161_1 ), hoisted_23_1 )];
-        end );
-    hoisted_162_1 := deduped_328_1[2];
-    hoisted_163_1 := List( deduped_274_1, function ( logic_new_func_x_2 )
-            return hoisted_162_1[1 + REM_INT( logic_new_func_x_2, hoisted_161_1 )];
-        end );
-    hoisted_147_1 := [ 0 .. deduped_291_1 - 1 ];
-    hoisted_166_1 := List( deduped_265_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_147_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_152_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_152_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_163_1[deduped_1_3] + hoisted_164_1[deduped_1_3] * hoisted_165_1))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_160_1 := List( deduped_266_1, function ( i_2 )
-            return Sum( List( hoisted_152_1, function ( k_3 )
-                      return hoisted_30_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_152_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_159_1 := deduped_281_1;
-    hoisted_156_1 := deduped_329_1[1];
-    hoisted_150_1 := deduped_327_1[1];
-    hoisted_154_1 := List( deduped_274_1, function ( logic_new_func_x_2 )
-            return hoisted_24_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_150_1 ), hoisted_23_1 )];
-        end );
-    hoisted_151_1 := deduped_328_1[1];
-    hoisted_153_1 := List( deduped_274_1, function ( logic_new_func_x_2 )
-            return hoisted_151_1[1 + REM_INT( logic_new_func_x_2, hoisted_150_1 )];
-        end );
-    hoisted_158_1 := List( deduped_265_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_147_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_152_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_152_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_153_1[deduped_1_3] + hoisted_154_1[deduped_1_3] * hoisted_156_1))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_157_1 := deduped_280_1;
-    hoisted_146_1 := Product( [ deduped_282_1, deduped_282_1, deduped_282_1 ] );
-    hoisted_145_1 := deduped_282_1 * deduped_282_1;
-    hoisted_144_1 := Product( [ deduped_280_1, deduped_281_1, deduped_282_1 ] );
-    hoisted_143_1 := deduped_282_1;
-    hoisted_142_1 := deduped_270_1;
-    hoisted_141_1 := deduped_253_1;
-    deduped_241_1 := Filtered( deduped_253_1, function ( x_2 )
-            local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_141_1[1 + x_2] );
-            deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_157_1 );
-            deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_144_1 ), hoisted_143_1 );
-            deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_142_1 ), hoisted_143_1 );
-            deduped_1_2 := 1 + REM_INT( QUO_INT( deduped_5_2, hoisted_157_1 ), hoisted_159_1 );
-            return deduped_2_2 + deduped_2_2 * hoisted_143_1 + deduped_3_2 * hoisted_145_1 + deduped_3_2 * hoisted_146_1 = hoisted_158_1[deduped_4_2] + hoisted_160_1[deduped_1_2] * hoisted_143_1 + hoisted_166_1[deduped_4_2] * hoisted_145_1 + hoisted_167_1[deduped_1_2] * hoisted_146_1;
-        end );
-    hoisted_75_1 := deduped_271_1;
-    hoisted_90_1 := List( deduped_262_1, function ( i_2 )
-            return Sum( List( hoisted_75_1, function ( k_3 )
-                      return hoisted_39_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_75_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_88_1 := deduped_321_1[2];
-    hoisted_84_1 := deduped_319_1[2];
-    hoisted_87_1 := List( deduped_271_1, function ( logic_new_func_x_2 )
-            return hoisted_35_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_84_1 ), hoisted_23_1 )];
-        end );
-    hoisted_85_1 := deduped_320_1[2];
-    hoisted_86_1 := List( deduped_271_1, function ( logic_new_func_x_2 )
-            return hoisted_85_1[1 + REM_INT( logic_new_func_x_2, hoisted_84_1 )];
-        end );
-    hoisted_70_1 := [ 0 .. deduped_289_1 - 1 ];
-    hoisted_89_1 := List( deduped_261_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_70_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_75_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_75_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_86_1[deduped_1_3] + hoisted_87_1[deduped_1_3] * hoisted_88_1))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_83_1 := List( deduped_262_1, function ( i_2 )
-            return Sum( List( hoisted_75_1, function ( k_3 )
-                      return hoisted_30_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_75_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_82_1 := deduped_278_1;
-    hoisted_79_1 := deduped_321_1[1];
-    hoisted_73_1 := deduped_319_1[1];
-    hoisted_77_1 := List( deduped_271_1, function ( logic_new_func_x_2 )
-            return hoisted_24_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_73_1 ), hoisted_23_1 )];
-        end );
-    hoisted_74_1 := deduped_320_1[1];
-    hoisted_76_1 := List( deduped_271_1, function ( logic_new_func_x_2 )
-            return hoisted_74_1[1 + REM_INT( logic_new_func_x_2, hoisted_73_1 )];
-        end );
-    hoisted_81_1 := List( deduped_261_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_70_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_75_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_75_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_76_1[deduped_1_3] + hoisted_77_1[deduped_1_3] * hoisted_79_1))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_80_1 := deduped_277_1;
-    hoisted_69_1 := Product( [ deduped_279_1, deduped_279_1, deduped_279_1 ] );
-    hoisted_68_1 := deduped_279_1 * deduped_279_1;
-    hoisted_67_1 := Product( [ deduped_277_1, deduped_278_1, deduped_279_1 ] );
-    hoisted_66_1 := deduped_279_1;
-    hoisted_65_1 := deduped_269_1;
-    hoisted_64_1 := deduped_252_1;
-    deduped_240_1 := Filtered( deduped_252_1, function ( x_2 )
-            local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_64_1[1 + x_2] );
-            deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_80_1 );
-            deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_67_1 ), hoisted_66_1 );
-            deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_65_1 ), hoisted_66_1 );
-            deduped_1_2 := 1 + REM_INT( QUO_INT( deduped_5_2, hoisted_80_1 ), hoisted_82_1 );
-            return deduped_2_2 + deduped_2_2 * hoisted_66_1 + deduped_3_2 * hoisted_68_1 + deduped_3_2 * hoisted_69_1 = hoisted_81_1[deduped_4_2] + hoisted_83_1[deduped_1_2] * hoisted_66_1 + hoisted_89_1[deduped_4_2] * hoisted_68_1 + hoisted_90_1[deduped_1_2] * hoisted_69_1;
-        end );
-    deduped_239_1 := List( deduped_257_1[1], Length );
-    deduped_238_1 := List( deduped_256_1[1], Length );
-    deduped_237_1 := deduped_239_1[2] * deduped_348_1;
-    deduped_236_1 := deduped_239_1[1] * deduped_346_1;
-    deduped_235_1 := deduped_238_1[2] * deduped_348_1;
-    deduped_234_1 := deduped_238_1[1] * deduped_346_1;
-    deduped_233_1 := [ 0 .. Length( deduped_249_1 ) - 1 ];
-    deduped_232_1 := [ 0 .. Length( deduped_248_1 ) - 1 ];
-    deduped_231_1 := [ 0 .. Length( deduped_241_1 ) - 1 ];
-    deduped_230_1 := [ 0 .. Length( deduped_240_1 ) - 1 ];
-    deduped_229_1 := deduped_345_1 ^ deduped_237_1;
-    deduped_228_1 := deduped_347_1 ^ deduped_237_1;
-    deduped_227_1 := deduped_345_1 ^ deduped_236_1;
-    deduped_226_1 := deduped_345_1 ^ deduped_235_1;
-    deduped_225_1 := deduped_347_1 ^ deduped_235_1;
-    deduped_224_1 := deduped_345_1 ^ deduped_234_1;
-    deduped_223_1 := [ 0 .. deduped_237_1 - 1 ];
-    deduped_222_1 := [ 0 .. deduped_235_1 - 1 ];
-    deduped_221_1 := [ 0 .. deduped_228_1 - 1 ];
-    deduped_220_1 := [ 0 .. deduped_227_1 - 1 ];
-    deduped_219_1 := [ 0 .. deduped_225_1 - 1 ];
-    deduped_218_1 := [ 0 .. deduped_224_1 - 1 ];
-    deduped_217_1 := [ 0 .. Product( [ deduped_227_1, deduped_228_1, deduped_229_1, deduped_229_1 ] ) - 1 ];
-    deduped_216_1 := [ 0 .. Product( [ deduped_224_1, deduped_225_1, deduped_226_1, deduped_226_1 ] ) - 1 ];
-    hoisted_197_1 := deduped_249_1;
-    hoisted_196_1 := deduped_233_1;
-    hoisted_215_1 := List( deduped_233_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_169_1[1 + hoisted_197_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_196_1[(1 + i_2)] ))]] );
-            return REM_INT( deduped_1_2, hoisted_185_1 ) + REM_INT( QUO_INT( deduped_1_2, hoisted_185_1 ), hoisted_187_1 ) * hoisted_185_1;
-        end );
-    hoisted_210_1 := deduped_306_1;
-    hoisted_206_1 := deduped_310_1;
-    hoisted_209_1 := List( deduped_276_1, function ( logic_new_func_x_2 )
-            return REM_INT( QUO_INT( logic_new_func_x_2, hoisted_206_1 ), hoisted_23_1 );
-        end );
-    hoisted_207_1 := deduped_302_1[2];
-    hoisted_208_1 := List( deduped_276_1, function ( logic_new_func_x_2 )
-            return hoisted_207_1[1 + REM_INT( logic_new_func_x_2, hoisted_206_1 )];
-        end );
-    hoisted_211_1 := List( deduped_266_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_152_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_29_1 ^ j_3 ), hoisted_29_1 );
-                end );
-            return Sum( List( hoisted_180_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_180_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_208_1[deduped_1_3] + hoisted_209_1[deduped_1_3] * hoisted_210_1))] * hoisted_29_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_203_1 := deduped_305_1;
-    hoisted_199_1 := deduped_309_1;
-    hoisted_125_1 := deduped_346_1;
-    hoisted_202_1 := List( deduped_275_1, function ( logic_new_func_x_2 )
-            return REM_INT( QUO_INT( logic_new_func_x_2, hoisted_199_1 ), hoisted_125_1 );
-        end );
-    hoisted_200_1 := deduped_302_1[1];
-    hoisted_201_1 := List( deduped_275_1, function ( logic_new_func_x_2 )
-            return hoisted_200_1[1 + REM_INT( logic_new_func_x_2, hoisted_199_1 )];
-        end );
-    hoisted_205_1 := List( deduped_265_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_147_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_175_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_175_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_201_1[deduped_1_3] + hoisted_202_1[deduped_1_3] * hoisted_203_1))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_204_1 := deduped_259_1;
-    hoisted_214_1 := List( deduped_259_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_204_1[1 + i_2] );
-            return hoisted_205_1[1 + REM_INT( deduped_1_2, hoisted_157_1 )] + hoisted_211_1[(1 + REM_INT( QUO_INT( deduped_1_2, hoisted_157_1 ), hoisted_159_1 ))] * hoisted_185_1;
-        end );
-    hoisted_213_1 := deduped_241_1;
-    hoisted_212_1 := deduped_231_1;
-    hoisted_120_1 := deduped_248_1;
-    hoisted_119_1 := deduped_232_1;
-    hoisted_139_1 := List( deduped_232_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_92_1[1 + hoisted_120_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_119_1[(1 + i_2)] ))]] );
-            return REM_INT( deduped_1_2, hoisted_108_1 ) + REM_INT( QUO_INT( deduped_1_2, hoisted_108_1 ), hoisted_110_1 ) * hoisted_108_1;
-        end );
-    hoisted_134_1 := deduped_304_1;
-    hoisted_130_1 := deduped_308_1;
-    hoisted_133_1 := List( deduped_273_1, function ( logic_new_func_x_2 )
-            return REM_INT( QUO_INT( logic_new_func_x_2, hoisted_130_1 ), hoisted_23_1 );
-        end );
-    hoisted_131_1 := deduped_299_1[2];
-    hoisted_132_1 := List( deduped_273_1, function ( logic_new_func_x_2 )
-            return hoisted_131_1[1 + REM_INT( logic_new_func_x_2, hoisted_130_1 )];
-        end );
-    hoisted_135_1 := List( deduped_262_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_75_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_29_1 ^ j_3 ), hoisted_29_1 );
-                end );
-            return Sum( List( hoisted_103_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_103_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_132_1[deduped_1_3] + hoisted_133_1[deduped_1_3] * hoisted_134_1))] * hoisted_29_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_127_1 := deduped_303_1;
-    hoisted_122_1 := deduped_307_1;
-    hoisted_126_1 := List( deduped_272_1, function ( logic_new_func_x_2 )
-            return REM_INT( QUO_INT( logic_new_func_x_2, hoisted_122_1 ), hoisted_125_1 );
-        end );
-    hoisted_123_1 := deduped_299_1[1];
-    hoisted_124_1 := List( deduped_272_1, function ( logic_new_func_x_2 )
-            return hoisted_123_1[1 + REM_INT( logic_new_func_x_2, hoisted_122_1 )];
-        end );
-    hoisted_129_1 := List( deduped_261_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_70_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_98_1, function ( k_3 )
-                      local deduped_1_3;
-                      deduped_1_3 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_98_1[(1 + k_3)] );
-                      return hoisted_1_2[(1 + (hoisted_124_1[deduped_1_3] + hoisted_126_1[deduped_1_3] * hoisted_127_1))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_128_1 := deduped_258_1;
-    hoisted_138_1 := List( deduped_258_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_128_1[1 + i_2] );
-            return hoisted_129_1[1 + REM_INT( deduped_1_2, hoisted_80_1 )] + hoisted_135_1[(1 + REM_INT( QUO_INT( deduped_1_2, hoisted_80_1 ), hoisted_82_1 ))] * hoisted_108_1;
-        end );
-    hoisted_137_1 := deduped_240_1;
-    hoisted_136_1 := deduped_230_1;
-    hoisted_48_1 := deduped_223_1;
-    hoisted_62_1 := List( deduped_221_1, function ( i_2 )
-            return Sum( List( hoisted_48_1, function ( k_3 )
-                      return hoisted_39_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_48_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_59_1 := deduped_247_1[2];
-    hoisted_58_1 := deduped_246_1[2];
-    hoisted_57_1 := deduped_245_1[2];
-    hoisted_60_1 := List( deduped_223_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_48_1[1 + i_2] );
-            return hoisted_58_1[1 + REM_INT( deduped_1_2, hoisted_57_1 )] + hoisted_35_1[(1 + REM_INT( QUO_INT( deduped_1_2, hoisted_57_1 ), hoisted_23_1 ))] * hoisted_59_1;
-        end );
-    hoisted_47_1 := [ 0 .. deduped_236_1 - 1 ];
-    hoisted_61_1 := List( deduped_220_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_47_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_48_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_60_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_48_1[(1 + k_3)] ))])] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_56_1 := List( deduped_221_1, function ( i_2 )
-            return Sum( List( hoisted_48_1, function ( k_3 )
-                      return hoisted_30_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_48_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_55_1 := deduped_228_1;
-    hoisted_51_1 := deduped_247_1[1];
-    hoisted_50_1 := deduped_246_1[1];
-    hoisted_49_1 := deduped_245_1[1];
-    hoisted_52_1 := List( deduped_223_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_48_1[1 + i_2] );
-            return hoisted_50_1[1 + REM_INT( deduped_1_2, hoisted_49_1 )] + hoisted_24_1[(1 + REM_INT( QUO_INT( deduped_1_2, hoisted_49_1 ), hoisted_23_1 ))] * hoisted_51_1;
-        end );
-    hoisted_54_1 := List( deduped_220_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_47_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_48_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_52_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_48_1[(1 + k_3)] ))])] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_53_1 := deduped_227_1;
-    hoisted_46_1 := Product( [ deduped_229_1, deduped_229_1, deduped_229_1 ] );
-    hoisted_45_1 := deduped_229_1 * deduped_229_1;
-    hoisted_44_1 := Product( [ deduped_227_1, deduped_228_1, deduped_229_1 ] );
-    hoisted_43_1 := deduped_229_1;
-    hoisted_42_1 := deduped_227_1 * deduped_228_1;
-    hoisted_41_1 := deduped_217_1;
-    hoisted_20_1 := deduped_222_1;
-    hoisted_40_1 := List( deduped_219_1, function ( i_2 )
-            return Sum( List( hoisted_20_1, function ( k_3 )
-                      return hoisted_39_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_20_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_36_1 := deduped_244_1[2];
-    hoisted_34_1 := deduped_243_1[2];
-    hoisted_33_1 := deduped_242_1[2];
-    hoisted_37_1 := List( deduped_222_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_20_1[1 + i_2] );
-            return hoisted_34_1[1 + REM_INT( deduped_1_2, hoisted_33_1 )] + hoisted_35_1[(1 + REM_INT( QUO_INT( deduped_1_2, hoisted_33_1 ), hoisted_23_1 ))] * hoisted_36_1;
-        end );
-    hoisted_19_1 := [ 0 .. deduped_234_1 - 1 ];
-    hoisted_38_1 := List( deduped_218_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_19_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_20_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_37_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_20_1[(1 + k_3)] ))])] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_32_1 := List( deduped_219_1, function ( i_2 )
-            return Sum( List( hoisted_20_1, function ( k_3 )
-                      return hoisted_30_1[(1 + REM_INT( QUO_INT( i_2, hoisted_29_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_20_1[(1 + k_3)] ) ), hoisted_29_1 ))] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_31_1 := deduped_225_1;
-    hoisted_25_1 := deduped_244_1[1];
-    hoisted_22_1 := deduped_243_1[1];
-    hoisted_21_1 := deduped_242_1[1];
-    hoisted_26_1 := List( deduped_222_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_20_1[1 + i_2] );
-            return hoisted_22_1[1 + REM_INT( deduped_1_2, hoisted_21_1 )] + hoisted_24_1[(1 + REM_INT( QUO_INT( deduped_1_2, hoisted_21_1 ), hoisted_23_1 ))] * hoisted_25_1;
-        end );
-    hoisted_28_1 := List( deduped_218_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_19_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_18_1 ^ j_3 ), hoisted_18_1 );
-                end );
-            return Sum( List( hoisted_20_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_26_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_20_1[(1 + k_3)] ))])] * hoisted_18_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_27_1 := deduped_224_1;
-    hoisted_17_1 := Product( [ deduped_226_1, deduped_226_1, deduped_226_1 ] );
-    hoisted_16_1 := deduped_226_1 * deduped_226_1;
-    hoisted_15_1 := Product( [ deduped_224_1, deduped_225_1, deduped_226_1 ] );
-    hoisted_14_1 := deduped_226_1;
-    hoisted_13_1 := deduped_224_1 * deduped_225_1;
-    hoisted_12_1 := deduped_216_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningTripleOfQuiver, NTuple( 3, Length( Filtered( deduped_216_1, function ( x_2 )
-                  local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-                  deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[1 + x_2] );
-                  deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_27_1 );
-                  deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_15_1 ), hoisted_14_1 );
-                  deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_13_1 ), hoisted_14_1 );
-                  deduped_1_2 := 1 + REM_INT( QUO_INT( deduped_5_2, hoisted_27_1 ), hoisted_31_1 );
-                  return deduped_2_2 + deduped_2_2 * hoisted_14_1 + deduped_3_2 * hoisted_16_1 + deduped_3_2 * hoisted_17_1 = hoisted_28_1[deduped_4_2] + hoisted_32_1[deduped_1_2] * hoisted_14_1 + hoisted_38_1[deduped_4_2] * hoisted_16_1 + hoisted_40_1[deduped_1_2] * hoisted_17_1;
-              end ) ), Length( Filtered( deduped_217_1, function ( x_2 )
-                  local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-                  deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_41_1[1 + x_2] );
-                  deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_53_1 );
-                  deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_44_1 ), hoisted_43_1 );
-                  deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_42_1 ), hoisted_43_1 );
-                  deduped_1_2 := 1 + REM_INT( QUO_INT( deduped_5_2, hoisted_53_1 ), hoisted_55_1 );
-                  return deduped_2_2 + deduped_2_2 * hoisted_43_1 + deduped_3_2 * hoisted_45_1 + deduped_3_2 * hoisted_46_1 = hoisted_54_1[deduped_4_2] + hoisted_56_1[deduped_1_2] * hoisted_43_1 + hoisted_61_1[deduped_4_2] * hoisted_45_1 + hoisted_62_1[deduped_1_2] * hoisted_46_1;
-              end ) ), ListN( List( deduped_230_1, function ( x_2 )
-                  local deduped_1_2;
-                  deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_64_1[1 + hoisted_137_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_136_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_136_1[(1 + x_2)] ))] ))]] );
-                  return -1 + SafePosition( hoisted_139_1, hoisted_138_1[(1 + (REM_INT( deduped_1_2, hoisted_80_1 ) + REM_INT( QUO_INT( deduped_1_2, hoisted_80_1 ), hoisted_82_1 ) * hoisted_80_1))] );
-              end ), List( deduped_231_1, function ( x_2 )
-                  local deduped_1_2;
-                  deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_141_1[1 + hoisted_213_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_212_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_212_1[(1 + x_2)] ))] ))]] );
-                  return -1 + SafePosition( hoisted_215_1, hoisted_214_1[(1 + (REM_INT( deduped_1_2, hoisted_157_1 ) + REM_INT( QUO_INT( deduped_1_2, hoisted_157_1 ), hoisted_159_1 ) * hoisted_157_1))] );
-              end ), function ( s_2, t_2 )
-                return NTuple( 2, s_2, t_2 );
+    hoisted_32_1 := deduped_39_1;
+    hoisted_31_1 := deduped_37_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningTripleOfQuiver, NTuple( 3, deduped_41_1, deduped_38_1, List( deduped_37_1, function ( logic_new_func_x_2 )
+                local deduped_1_2, deduped_2_2;
+                deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + hoisted_32_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_31_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_31_1[(1 + logic_new_func_x_2)] ))] ))]] );
+                deduped_1_2 := 1 + (REM_INT( deduped_2_2, hoisted_13_1 ) + REM_INT( QUO_INT( deduped_2_2, hoisted_13_1 ), hoisted_17_1 ) * hoisted_13_1);
+                return NTuple( 2, -1 + SafePosition( hoisted_34_1, hoisted_33_1[deduped_1_2] ), -1 + SafePosition( hoisted_34_1, hoisted_36_1[deduped_1_2] ) );
             end ) ) );
 end
 ########

--- a/gap/precompiled_categories/FinQuiversPrecompiled.gi
+++ b/gap/precompiled_categories/FinQuiversPrecompiled.gi
@@ -81,37 +81,40 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1;
-    deduped_34_1 := DefiningTripleOfQuiver( arg2_1 );
-    deduped_33_1 := DefiningTripleOfQuiver( arg3_1 );
-    deduped_32_1 := deduped_33_1[3];
-    deduped_31_1 := deduped_34_1[3];
-    deduped_30_1 := deduped_34_1[2];
-    deduped_29_1 := deduped_33_1[2];
-    deduped_28_1 := deduped_34_1[1];
-    deduped_27_1 := deduped_33_1[1];
-    deduped_26_1 := deduped_27_1 ^ deduped_30_1;
-    deduped_25_1 := deduped_29_1 ^ deduped_30_1;
-    deduped_24_1 := deduped_27_1 ^ deduped_28_1;
-    deduped_23_1 := [ 0 .. deduped_25_1 - 1 ];
-    deduped_22_1 := [ 0 .. deduped_24_1 - 1 ];
-    deduped_21_1 := [ 0 .. Product( [ deduped_24_1, deduped_25_1, deduped_26_1, deduped_26_1 ] ) - 1 ];
-    hoisted_19_1 := List( deduped_32_1, function ( a_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1;
+    deduped_37_1 := DefiningTripleOfQuiver( arg2_1 );
+    deduped_36_1 := DefiningTripleOfQuiver( arg3_1 );
+    deduped_35_1 := deduped_36_1[3];
+    deduped_34_1 := deduped_37_1[3];
+    deduped_33_1 := deduped_37_1[2];
+    deduped_32_1 := deduped_36_1[2];
+    deduped_31_1 := deduped_37_1[1];
+    deduped_30_1 := deduped_36_1[1];
+    deduped_29_1 := deduped_30_1 ^ deduped_33_1;
+    deduped_28_1 := deduped_32_1 ^ deduped_33_1;
+    deduped_27_1 := deduped_30_1 ^ deduped_31_1;
+    deduped_26_1 := deduped_29_1 * deduped_29_1;
+    deduped_25_1 := deduped_27_1 * deduped_28_1;
+    deduped_24_1 := [ 0 .. deduped_28_1 - 1 ];
+    deduped_23_1 := [ 0 .. deduped_27_1 - 1 ];
+    deduped_22_1 := deduped_25_1 * deduped_29_1;
+    deduped_21_1 := [ 0 .. deduped_22_1 * deduped_29_1 - 1 ];
+    hoisted_19_1 := List( deduped_35_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_13_1 := deduped_29_1;
-    hoisted_9_1 := [ 0 .. deduped_30_1 - 1 ];
-    hoisted_7_1 := deduped_27_1;
-    hoisted_20_1 := List( deduped_23_1, function ( i_2 )
+    hoisted_13_1 := deduped_32_1;
+    hoisted_9_1 := [ 0 .. deduped_33_1 - 1 ];
+    hoisted_7_1 := deduped_30_1;
+    hoisted_20_1 := List( deduped_24_1, function ( i_2 )
             return Sum( List( hoisted_9_1, function ( k_3 )
                       return hoisted_19_1[(1 + REM_INT( QUO_INT( i_2, hoisted_13_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ) ), hoisted_13_1 ))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_17_1 := List( deduped_31_1, function ( a_2 )
+    hoisted_17_1 := List( deduped_34_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_8_1 := [ 0 .. deduped_28_1 - 1 ];
-    hoisted_18_1 := List( deduped_22_1, function ( i_2 )
+    hoisted_8_1 := [ 0 .. deduped_31_1 - 1 ];
+    hoisted_18_1 := List( deduped_23_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
@@ -120,19 +123,19 @@ function ( cat_1, arg2_1, arg3_1 )
                       return hoisted_1_2[(1 + hoisted_17_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ))])] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_14_1 := List( deduped_32_1, function ( a_2 )
+    hoisted_14_1 := List( deduped_35_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_16_1 := List( deduped_23_1, function ( i_2 )
+    hoisted_16_1 := List( deduped_24_1, function ( i_2 )
             return Sum( List( hoisted_9_1, function ( k_3 )
                       return hoisted_14_1[(1 + REM_INT( QUO_INT( i_2, hoisted_13_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ) ), hoisted_13_1 ))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_15_1 := deduped_25_1;
-    hoisted_10_1 := List( deduped_31_1, function ( a_2 )
+    hoisted_15_1 := deduped_28_1;
+    hoisted_10_1 := List( deduped_34_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_12_1 := List( deduped_22_1, function ( i_2 )
+    hoisted_12_1 := List( deduped_23_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
@@ -141,12 +144,12 @@ function ( cat_1, arg2_1, arg3_1 )
                       return hoisted_1_2[(1 + hoisted_10_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ))])] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_11_1 := deduped_24_1;
-    hoisted_6_1 := Product( [ deduped_26_1, deduped_26_1, deduped_26_1 ] );
-    hoisted_5_1 := deduped_26_1 * deduped_26_1;
-    hoisted_4_1 := Product( [ deduped_24_1, deduped_25_1, deduped_26_1 ] );
-    hoisted_3_1 := deduped_26_1;
-    hoisted_2_1 := deduped_24_1 * deduped_25_1;
+    hoisted_11_1 := deduped_27_1;
+    hoisted_6_1 := deduped_26_1 * deduped_29_1;
+    hoisted_5_1 := deduped_26_1;
+    hoisted_4_1 := deduped_22_1;
+    hoisted_3_1 := deduped_29_1;
+    hoisted_2_1 := deduped_25_1;
     hoisted_1_1 := deduped_21_1;
     return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_21_1, function ( x_2 )
                 local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
@@ -167,43 +170,46 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, hoisted_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1;
-    deduped_57_1 := DefiningTripleOfQuiver( range_1 );
-    deduped_56_1 := DefiningTripleOfQuiver( source_1 );
-    deduped_55_1 := Length( Source( alpha_1 ) );
-    deduped_54_1 := deduped_57_1[3];
-    deduped_53_1 := deduped_56_1[3];
-    deduped_52_1 := deduped_57_1[2];
-    deduped_51_1 := deduped_57_1[1];
-    deduped_50_1 := deduped_56_1[2];
-    deduped_49_1 := deduped_56_1[1];
-    deduped_48_1 := deduped_51_1 ^ deduped_50_1;
-    deduped_47_1 := deduped_52_1 ^ deduped_50_1;
-    deduped_46_1 := deduped_51_1 ^ deduped_49_1;
-    deduped_45_1 := [ 0 .. deduped_55_1 - 1 ];
-    deduped_44_1 := [ 0 .. deduped_50_1 - 1 ];
-    deduped_43_1 := [ 0 .. deduped_49_1 - 1 ];
-    deduped_42_1 := [ 0 .. deduped_55_1 * deduped_50_1 - 1 ];
-    deduped_41_1 := [ 0 .. deduped_55_1 * deduped_49_1 - 1 ];
-    deduped_40_1 := [ 0 .. deduped_47_1 - 1 ];
-    deduped_39_1 := [ 0 .. deduped_46_1 - 1 ];
-    deduped_38_1 := [ 0 .. Product( [ deduped_46_1, deduped_47_1, deduped_48_1, deduped_48_1 ] ) - 1 ];
-    hoisted_19_1 := List( deduped_54_1, function ( a_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, hoisted_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1;
+    deduped_60_1 := DefiningTripleOfQuiver( range_1 );
+    deduped_59_1 := DefiningTripleOfQuiver( source_1 );
+    deduped_58_1 := Length( Source( alpha_1 ) );
+    deduped_57_1 := deduped_60_1[3];
+    deduped_56_1 := deduped_59_1[3];
+    deduped_55_1 := deduped_60_1[2];
+    deduped_54_1 := deduped_60_1[1];
+    deduped_53_1 := deduped_59_1[2];
+    deduped_52_1 := deduped_59_1[1];
+    deduped_51_1 := deduped_54_1 ^ deduped_53_1;
+    deduped_50_1 := deduped_55_1 ^ deduped_53_1;
+    deduped_49_1 := deduped_54_1 ^ deduped_52_1;
+    deduped_48_1 := [ 0 .. deduped_58_1 - 1 ];
+    deduped_47_1 := [ 0 .. deduped_53_1 - 1 ];
+    deduped_46_1 := [ 0 .. deduped_52_1 - 1 ];
+    deduped_45_1 := deduped_51_1 * deduped_51_1;
+    deduped_44_1 := deduped_49_1 * deduped_50_1;
+    deduped_43_1 := [ 0 .. deduped_58_1 * deduped_53_1 - 1 ];
+    deduped_42_1 := [ 0 .. deduped_58_1 * deduped_52_1 - 1 ];
+    deduped_41_1 := [ 0 .. deduped_50_1 - 1 ];
+    deduped_40_1 := [ 0 .. deduped_49_1 - 1 ];
+    deduped_39_1 := deduped_44_1 * deduped_51_1;
+    deduped_38_1 := [ 0 .. deduped_39_1 * deduped_51_1 - 1 ];
+    hoisted_19_1 := List( deduped_57_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_13_1 := deduped_52_1;
-    hoisted_10_1 := deduped_44_1;
-    hoisted_2_1 := deduped_51_1;
-    hoisted_20_1 := List( deduped_40_1, function ( i_2 )
+    hoisted_13_1 := deduped_55_1;
+    hoisted_10_1 := deduped_47_1;
+    hoisted_2_1 := deduped_54_1;
+    hoisted_20_1 := List( deduped_41_1, function ( i_2 )
             return Sum( List( hoisted_10_1, function ( k_3 )
                       return hoisted_19_1[(1 + REM_INT( QUO_INT( i_2, hoisted_13_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ) ), hoisted_13_1 ))] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_17_1 := List( deduped_53_1, function ( a_2 )
+    hoisted_17_1 := List( deduped_56_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_9_1 := deduped_43_1;
-    hoisted_18_1 := List( deduped_39_1, function ( i_2 )
+    hoisted_9_1 := deduped_46_1;
+    hoisted_18_1 := List( deduped_40_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := List( hoisted_9_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_2_1 ^ j_3 ), hoisted_2_1 );
@@ -212,19 +218,19 @@ function ( cat_1, source_1, range_1, alpha_1 )
                       return hoisted_1_2[(1 + hoisted_17_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ))])] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_14_1 := List( deduped_54_1, function ( a_2 )
+    hoisted_14_1 := List( deduped_57_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_16_1 := List( deduped_40_1, function ( i_2 )
+    hoisted_16_1 := List( deduped_41_1, function ( i_2 )
             return Sum( List( hoisted_10_1, function ( k_3 )
                       return hoisted_14_1[(1 + REM_INT( QUO_INT( i_2, hoisted_13_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ) ), hoisted_13_1 ))] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_15_1 := deduped_47_1;
-    hoisted_11_1 := List( deduped_53_1, function ( a_2 )
+    hoisted_15_1 := deduped_50_1;
+    hoisted_11_1 := List( deduped_56_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_12_1 := List( deduped_39_1, function ( i_2 )
+    hoisted_12_1 := List( deduped_40_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := List( hoisted_9_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_2_1 ^ j_3 ), hoisted_2_1 );
@@ -233,13 +239,13 @@ function ( cat_1, source_1, range_1, alpha_1 )
                       return hoisted_1_2[(1 + hoisted_11_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ))])] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_8_1 := Product( [ deduped_48_1, deduped_48_1, deduped_48_1 ] );
-    hoisted_7_1 := deduped_48_1 * deduped_48_1;
-    hoisted_6_1 := Product( [ deduped_46_1, deduped_47_1, deduped_48_1 ] );
-    hoisted_5_1 := deduped_48_1;
-    hoisted_4_1 := deduped_46_1 * deduped_47_1;
+    hoisted_8_1 := deduped_45_1 * deduped_51_1;
+    hoisted_7_1 := deduped_45_1;
+    hoisted_6_1 := deduped_39_1;
+    hoisted_5_1 := deduped_51_1;
+    hoisted_4_1 := deduped_44_1;
     hoisted_3_1 := deduped_38_1;
-    hoisted_1_1 := deduped_46_1;
+    hoisted_1_1 := deduped_49_1;
     deduped_37_1 := Filtered( deduped_38_1, function ( x_2 )
             local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
             deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[1 + x_2] );
@@ -250,44 +256,44 @@ function ( cat_1, source_1, range_1, alpha_1 )
             return deduped_2_2 + deduped_2_2 * hoisted_5_1 + deduped_3_2 * hoisted_7_1 + deduped_3_2 * hoisted_8_1 = hoisted_12_1[deduped_4_2] + hoisted_16_1[deduped_1_2] * hoisted_5_1 + hoisted_18_1[deduped_4_2] * hoisted_7_1 + hoisted_20_1[deduped_1_2] * hoisted_8_1;
         end );
     deduped_36_1 := [ 0 .. Length( deduped_37_1 ) - 1 ];
-    hoisted_34_1 := List( [ 0 .. deduped_47_1 * deduped_50_1 - 1 ], function ( i_2 )
+    hoisted_34_1 := List( [ 0 .. deduped_50_1 * deduped_53_1 - 1 ], function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_13_1 ^ QUO_INT( i_2, hoisted_15_1 ) ), hoisted_13_1 );
         end );
-    hoisted_33_1 := deduped_50_1;
+    hoisted_33_1 := deduped_53_1;
     hoisted_21_1 := deduped_37_1;
     hoisted_30_1 := List( deduped_36_1, function ( i_2 )
             return REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[1 + hoisted_21_1[(1 + i_2)]] ), hoisted_1_1 ), hoisted_15_1 );
         end );
     hoisted_22_1 := AsList( alpha_1 );
-    hoisted_32_1 := List( deduped_45_1, function ( i_2 )
+    hoisted_32_1 := List( deduped_48_1, function ( i_2 )
             return hoisted_30_1[1 + hoisted_22_1[(1 + i_2)]];
         end );
-    hoisted_31_1 := deduped_42_1;
-    hoisted_25_1 := deduped_55_1;
-    hoisted_35_1 := List( deduped_42_1, function ( logic_new_func_x_2 )
+    hoisted_31_1 := deduped_43_1;
+    hoisted_25_1 := deduped_58_1;
+    hoisted_35_1 := List( deduped_43_1, function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_31_1[1 + logic_new_func_x_2] );
             return hoisted_34_1[1 + (hoisted_32_1[1 + REM_INT( deduped_1_2, hoisted_25_1 )] + REM_INT( QUO_INT( deduped_1_2, hoisted_25_1 ), hoisted_33_1 ) * hoisted_15_1)];
         end );
-    hoisted_28_1 := List( [ 0 .. deduped_46_1 * deduped_49_1 - 1 ], function ( i_2 )
+    hoisted_28_1 := List( [ 0 .. deduped_49_1 * deduped_52_1 - 1 ], function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_2_1 ^ QUO_INT( i_2, hoisted_1_1 ) ), hoisted_2_1 );
         end );
-    hoisted_27_1 := deduped_49_1;
+    hoisted_27_1 := deduped_52_1;
     hoisted_23_1 := List( deduped_36_1, function ( i_2 )
             return REM_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[1 + hoisted_21_1[(1 + i_2)]] ), hoisted_1_1 );
         end );
-    hoisted_26_1 := List( deduped_45_1, function ( i_2 )
+    hoisted_26_1 := List( deduped_48_1, function ( i_2 )
             return hoisted_23_1[1 + hoisted_22_1[(1 + i_2)]];
         end );
-    hoisted_24_1 := deduped_41_1;
-    hoisted_29_1 := List( deduped_41_1, function ( logic_new_func_x_2 )
+    hoisted_24_1 := deduped_42_1;
+    hoisted_29_1 := List( deduped_42_1, function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_24_1[1 + logic_new_func_x_2] );
             return hoisted_28_1[1 + (hoisted_26_1[1 + REM_INT( deduped_1_2, hoisted_25_1 )] + REM_INT( QUO_INT( deduped_1_2, hoisted_25_1 ), hoisted_27_1 ) * hoisted_1_1)];
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfQuiverMorphism, NTuple( 2, List( deduped_43_1, function ( i_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfQuiverMorphism, NTuple( 2, List( deduped_46_1, function ( i_2 )
                 return hoisted_29_1[1 + i_2];
-            end ), List( deduped_44_1, function ( i_2 )
+            end ), List( deduped_47_1, function ( i_2 )
                 return hoisted_35_1[1 + i_2];
             end ) ) );
 end
@@ -300,39 +306,42 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1;
-    deduped_48_1 := DefiningTripleOfQuiver( arg2_1 );
-    deduped_47_1 := DefiningTripleOfQuiver( arg3_1 );
-    deduped_46_1 := deduped_47_1[3];
-    deduped_45_1 := deduped_48_1[3];
-    deduped_44_1 := deduped_48_1[2];
-    deduped_43_1 := deduped_47_1[2];
-    deduped_42_1 := deduped_48_1[1];
-    deduped_41_1 := deduped_47_1[1];
-    deduped_40_1 := deduped_41_1 ^ deduped_44_1;
-    deduped_39_1 := deduped_43_1 ^ deduped_44_1;
-    deduped_38_1 := deduped_41_1 ^ deduped_42_1;
-    deduped_37_1 := [ 0 .. deduped_44_1 - 1 ];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1;
+    deduped_51_1 := DefiningTripleOfQuiver( arg2_1 );
+    deduped_50_1 := DefiningTripleOfQuiver( arg3_1 );
+    deduped_49_1 := deduped_50_1[3];
+    deduped_48_1 := deduped_51_1[3];
+    deduped_47_1 := deduped_51_1[2];
+    deduped_46_1 := deduped_50_1[2];
+    deduped_45_1 := deduped_51_1[1];
+    deduped_44_1 := deduped_50_1[1];
+    deduped_43_1 := deduped_44_1 ^ deduped_47_1;
+    deduped_42_1 := deduped_46_1 ^ deduped_47_1;
+    deduped_41_1 := deduped_44_1 ^ deduped_45_1;
+    deduped_40_1 := [ 0 .. deduped_47_1 - 1 ];
+    deduped_39_1 := [ 0 .. deduped_45_1 - 1 ];
+    deduped_38_1 := deduped_43_1 * deduped_43_1;
+    deduped_37_1 := deduped_41_1 * deduped_42_1;
     deduped_36_1 := [ 0 .. deduped_42_1 - 1 ];
-    deduped_35_1 := [ 0 .. deduped_39_1 - 1 ];
-    deduped_34_1 := [ 0 .. deduped_38_1 - 1 ];
-    deduped_33_1 := [ 0 .. Product( [ deduped_38_1, deduped_39_1, deduped_40_1, deduped_40_1 ] ) - 1 ];
-    hoisted_19_1 := List( deduped_46_1, function ( a_2 )
+    deduped_35_1 := [ 0 .. deduped_41_1 - 1 ];
+    deduped_34_1 := deduped_37_1 * deduped_43_1;
+    deduped_33_1 := [ 0 .. deduped_34_1 * deduped_43_1 - 1 ];
+    hoisted_19_1 := List( deduped_49_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_13_1 := deduped_43_1;
-    hoisted_9_1 := deduped_37_1;
-    hoisted_7_1 := deduped_41_1;
-    hoisted_20_1 := List( deduped_35_1, function ( i_2 )
+    hoisted_13_1 := deduped_46_1;
+    hoisted_9_1 := deduped_40_1;
+    hoisted_7_1 := deduped_44_1;
+    hoisted_20_1 := List( deduped_36_1, function ( i_2 )
             return Sum( List( hoisted_9_1, function ( k_3 )
                       return hoisted_19_1[(1 + REM_INT( QUO_INT( i_2, hoisted_13_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ) ), hoisted_13_1 ))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_17_1 := List( deduped_45_1, function ( a_2 )
+    hoisted_17_1 := List( deduped_48_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_8_1 := deduped_36_1;
-    hoisted_18_1 := List( deduped_34_1, function ( i_2 )
+    hoisted_8_1 := deduped_39_1;
+    hoisted_18_1 := List( deduped_35_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
@@ -341,19 +350,19 @@ function ( cat_1, arg2_1, arg3_1 )
                       return hoisted_1_2[(1 + hoisted_17_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ))])] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_14_1 := List( deduped_46_1, function ( a_2 )
+    hoisted_14_1 := List( deduped_49_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_16_1 := List( deduped_35_1, function ( i_2 )
+    hoisted_16_1 := List( deduped_36_1, function ( i_2 )
             return Sum( List( hoisted_9_1, function ( k_3 )
                       return hoisted_14_1[(1 + REM_INT( QUO_INT( i_2, hoisted_13_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ) ), hoisted_13_1 ))] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_15_1 := deduped_39_1;
-    hoisted_10_1 := List( deduped_45_1, function ( a_2 )
+    hoisted_15_1 := deduped_42_1;
+    hoisted_10_1 := List( deduped_48_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_12_1 := List( deduped_34_1, function ( i_2 )
+    hoisted_12_1 := List( deduped_35_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := List( hoisted_8_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ j_3 ), hoisted_7_1 );
@@ -362,12 +371,12 @@ function ( cat_1, arg2_1, arg3_1 )
                       return hoisted_1_2[(1 + hoisted_10_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + k_3)] ))])] * hoisted_7_1 ^ k_3;
                   end ) );
         end );
-    hoisted_11_1 := deduped_38_1;
-    hoisted_6_1 := Product( [ deduped_40_1, deduped_40_1, deduped_40_1 ] );
-    hoisted_5_1 := deduped_40_1 * deduped_40_1;
-    hoisted_4_1 := Product( [ deduped_38_1, deduped_39_1, deduped_40_1 ] );
-    hoisted_3_1 := deduped_40_1;
-    hoisted_2_1 := deduped_38_1 * deduped_39_1;
+    hoisted_11_1 := deduped_41_1;
+    hoisted_6_1 := deduped_38_1 * deduped_43_1;
+    hoisted_5_1 := deduped_38_1;
+    hoisted_4_1 := deduped_34_1;
+    hoisted_3_1 := deduped_43_1;
+    hoisted_2_1 := deduped_37_1;
     hoisted_1_1 := deduped_33_1;
     deduped_32_1 := Filtered( deduped_33_1, function ( x_2 )
             local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
@@ -380,18 +389,18 @@ function ( cat_1, arg2_1, arg3_1 )
         end );
     deduped_31_1 := Length( deduped_32_1 );
     deduped_30_1 := [ 0 .. deduped_31_1 - 1 ];
-    hoisted_29_1 := List( [ 0 .. deduped_39_1 * deduped_44_1 - 1 ], function ( i_2 )
+    hoisted_29_1 := List( [ 0 .. deduped_42_1 * deduped_47_1 - 1 ], function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_13_1 ^ QUO_INT( i_2, hoisted_15_1 ) ), hoisted_13_1 );
         end );
-    hoisted_27_1 := deduped_44_1;
-    hoisted_28_1 := List( deduped_37_1, function ( logic_new_func_x_2 )
+    hoisted_27_1 := deduped_47_1;
+    hoisted_28_1 := List( deduped_40_1, function ( logic_new_func_x_2 )
             return REM_INT( logic_new_func_x_2, hoisted_27_1 );
         end );
-    hoisted_26_1 := List( [ 0 .. deduped_38_1 * deduped_42_1 - 1 ], function ( i_2 )
+    hoisted_26_1 := List( [ 0 .. deduped_41_1 * deduped_45_1 - 1 ], function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_7_1 ^ QUO_INT( i_2, hoisted_11_1 ) ), hoisted_7_1 );
         end );
-    hoisted_24_1 := deduped_42_1;
-    hoisted_25_1 := List( deduped_36_1, function ( logic_new_func_x_2 )
+    hoisted_24_1 := deduped_45_1;
+    hoisted_25_1 := List( deduped_39_1, function ( logic_new_func_x_2 )
             return REM_INT( logic_new_func_x_2, hoisted_24_1 );
         end );
     hoisted_23_1 := deduped_32_1;

--- a/gap/precompiled_categories/PreSheavesInSkeletalFinSetsPrecompiled.gi
+++ b/gap/precompiled_categories/PreSheavesInSkeletalFinSetsPrecompiled.gi
@@ -10,15 +10,16 @@ BindGlobal( "ADD_FUNCTIONS_FOR_PreSheavesInSkeletalFinSetsPrecompiled", function
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    deduped_3_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, Length, 0 );
-    hoisted_2_1 := CreateCapCategoryMorphismWithAttributes( deduped_4_1, deduped_3_1, deduped_3_1, AsList, [  ] );
-    hoisted_1_1 := deduped_3_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, Length, 0 );
+    deduped_3_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_2_1 := CreateCapCategoryMorphismWithAttributes( deduped_6_1, deduped_4_1, deduped_4_1, AsList, [  ] );
+    hoisted_1_1 := deduped_4_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_3_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_3_1[2] ) ], function ( m_2 )
                 return hoisted_2_1;
             end ) ) );
 end
@@ -31,14 +32,15 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
-    deduped_6_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_5_1 := Range( cat_1 );
-    deduped_4_1 := deduped_6_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1;
+    deduped_7_1 := Range( cat_1 );
+    deduped_6_1 := Source( cat_1 );
+    deduped_5_1 := DefiningPairOfUnderlyingQuiver( deduped_6_1 );
+    deduped_4_1 := deduped_5_1[2];
     hoisted_3_1 := [ 1 .. Length( arg2_1 ) ];
     hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_5_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_6_1[1] ], function ( o_2 )
+    hoisted_1_1 := deduped_7_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_6_1, Range, deduped_7_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_1_1, Length, Sum( List( arg2_1, function ( logic_new_func_x_3 )
                             return Length( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
                         end ) ) );
@@ -86,7 +88,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := [ 1 .. k_1 - 1 ];
     hoisted_2_1 := ValuesOfPreSheaf( P_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_5_1 ) )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_5_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_5_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return Length( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -108,7 +110,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := Range( cat_1 );
     hoisted_2_1 := ValuesOfPreSheaf( T_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_3_1, hoisted_1_1[o_2], hoisted_2_1[o_2], AsList, Concatenation( List( tau_1, function ( logic_new_func_x_3 )
                           return AsList( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
                       end ) ) );
@@ -126,18 +128,18 @@ function ( cat_1, arg2_1, arg3_1 )
     local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1;
     deduped_30_1 := ValuesOfPreSheaf( arg2_1 );
     deduped_29_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_28_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_27_1 := deduped_30_1[2];
-    deduped_26_1 := deduped_29_1[2];
-    deduped_25_1 := deduped_28_1[2];
-    deduped_24_1 := deduped_28_1[1];
+    deduped_28_1 := deduped_30_1[2];
+    deduped_27_1 := deduped_29_1[2];
+    deduped_26_1 := DefiningPairOfUnderlyingQuiver( Source( cat_1 ) );
+    deduped_25_1 := deduped_26_1[2];
+    deduped_24_1 := deduped_26_1[1];
     deduped_23_1 := Length( deduped_25_1 );
     deduped_22_1 := [ 1 .. deduped_23_1 ];
     deduped_21_1 := [ 0 .. deduped_23_1 * 2 - 1 ];
-    hoisted_4_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_4_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_3_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
     hoisted_2_1 := List( deduped_30_1[1], Length );
@@ -148,13 +150,13 @@ function ( cat_1, arg2_1, arg3_1 )
               return hoisted_3_1[logic_new_func_x_2] ^ hoisted_4_1[logic_new_func_x_2];
           end ) );
     deduped_19_1 := [ 0 .. Product( deduped_20_1 ) - 1 ];
-    hoisted_17_1 := List( deduped_26_1, AsList );
-    hoisted_16_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
+    hoisted_17_1 := List( deduped_27_1, AsList );
+    hoisted_16_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
     hoisted_15_1 := deduped_25_1;
-    hoisted_14_1 := List( deduped_27_1, AsList );
-    hoisted_13_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_14_1 := List( deduped_28_1, AsList );
+    hoisted_13_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
     hoisted_6_1 := deduped_19_1;
@@ -243,22 +245,22 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
     local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, hoisted_35_1, hoisted_36_1, hoisted_37_1, hoisted_38_1, hoisted_39_1, hoisted_40_1, hoisted_41_1, hoisted_42_1, hoisted_43_1, hoisted_44_1, hoisted_45_1, hoisted_46_1, hoisted_47_1, hoisted_48_1, hoisted_49_1, hoisted_50_1, hoisted_51_1, hoisted_52_1, hoisted_53_1, hoisted_54_1, hoisted_55_1, hoisted_56_1, hoisted_57_1, hoisted_58_1, hoisted_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1, deduped_64_1, deduped_65_1, deduped_66_1, deduped_67_1, deduped_68_1, deduped_69_1, deduped_70_1, deduped_71_1, deduped_72_1, deduped_73_1, deduped_74_1, deduped_75_1, deduped_76_1, deduped_77_1, deduped_78_1, deduped_79_1, deduped_80_1, deduped_81_1, deduped_82_1, deduped_83_1, deduped_84_1, deduped_85_1, deduped_86_1, deduped_87_1, deduped_88_1, deduped_89_1, deduped_90_1, deduped_91_1, deduped_92_1, deduped_93_1;
     deduped_93_1 := ValuesOnAllObjects( alpha_1 );
     deduped_92_1 := ValuesOnAllObjects( beta_1 );
-    deduped_91_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_90_1 := Range( cat_1 );
-    deduped_89_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
-    deduped_88_1 := ValuesOfPreSheaf( Range( beta_1 ) );
-    deduped_87_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
-    deduped_86_1 := ValuesOfPreSheaf( Source( beta_1 ) );
-    deduped_85_1 := deduped_91_1[2];
-    deduped_84_1 := deduped_91_1[1];
-    deduped_83_1 := [ 1 .. deduped_84_1 ];
-    deduped_82_1 := deduped_89_1[2];
-    deduped_81_1 := deduped_88_1[2];
-    deduped_80_1 := deduped_84_1 - 1;
-    deduped_79_1 := deduped_87_1[2];
-    deduped_78_1 := deduped_86_1[2];
-    deduped_77_1 := Length( deduped_85_1 );
-    deduped_76_1 := [ 0 .. deduped_80_1 ];
+    deduped_91_1 := Range( cat_1 );
+    deduped_90_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
+    deduped_89_1 := ValuesOfPreSheaf( Range( beta_1 ) );
+    deduped_88_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
+    deduped_87_1 := ValuesOfPreSheaf( Source( beta_1 ) );
+    deduped_86_1 := DefiningPairOfUnderlyingQuiver( Source( cat_1 ) );
+    deduped_85_1 := deduped_90_1[2];
+    deduped_84_1 := deduped_89_1[2];
+    deduped_83_1 := deduped_88_1[2];
+    deduped_82_1 := deduped_87_1[2];
+    deduped_81_1 := deduped_86_1[2];
+    deduped_80_1 := deduped_86_1[1];
+    deduped_79_1 := [ 1 .. deduped_80_1 ];
+    deduped_78_1 := deduped_80_1 - 1;
+    deduped_77_1 := Length( deduped_81_1 );
+    deduped_76_1 := [ 0 .. deduped_78_1 ];
     deduped_75_1 := [ 1 .. deduped_77_1 ];
     hoisted_41_1 := List( deduped_93_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
@@ -266,47 +268,47 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
     hoisted_40_1 := List( deduped_92_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    deduped_74_1 := List( deduped_83_1, function ( logic_new_func_x_2 )
+    deduped_74_1 := List( deduped_79_1, function ( logic_new_func_x_2 )
             return hoisted_40_1[logic_new_func_x_2] ^ hoisted_41_1[logic_new_func_x_2];
         end );
-    deduped_73_1 := [ 1 .. deduped_84_1 + deduped_77_1 ];
+    deduped_73_1 := [ 1 .. deduped_80_1 + deduped_77_1 ];
     deduped_72_1 := [ 0 .. deduped_77_1 * 2 - 1 ];
-    hoisted_22_1 := List( deduped_82_1, function ( logic_new_func_x_2 )
+    hoisted_22_1 := List( deduped_85_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_21_1 := List( deduped_81_1, function ( logic_new_func_x_2 )
+    hoisted_21_1 := List( deduped_84_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_20_1 := List( deduped_89_1[1], Length );
-    hoisted_19_1 := List( deduped_88_1[1], Length );
-    deduped_71_1 := Concatenation( List( deduped_83_1, function ( logic_new_func_x_2 )
+    hoisted_20_1 := List( deduped_90_1[1], Length );
+    hoisted_19_1 := List( deduped_89_1[1], Length );
+    deduped_71_1 := Concatenation( List( deduped_79_1, function ( logic_new_func_x_2 )
               return hoisted_19_1[logic_new_func_x_2] ^ hoisted_20_1[logic_new_func_x_2];
           end ), List( deduped_75_1, function ( logic_new_func_x_2 )
               return hoisted_21_1[logic_new_func_x_2] ^ hoisted_22_1[logic_new_func_x_2];
           end ) );
-    hoisted_4_1 := List( deduped_79_1, function ( logic_new_func_x_2 )
+    hoisted_4_1 := List( deduped_83_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_3_1 := List( deduped_78_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := List( deduped_82_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_2_1 := List( deduped_87_1[1], Length );
-    hoisted_1_1 := List( deduped_86_1[1], Length );
-    deduped_70_1 := Concatenation( List( deduped_83_1, function ( logic_new_func_x_2 )
+    hoisted_2_1 := List( deduped_88_1[1], Length );
+    hoisted_1_1 := List( deduped_87_1[1], Length );
+    deduped_70_1 := Concatenation( List( deduped_79_1, function ( logic_new_func_x_2 )
               return hoisted_1_1[logic_new_func_x_2] ^ hoisted_2_1[logic_new_func_x_2];
           end ), List( deduped_75_1, function ( logic_new_func_x_2 )
               return hoisted_3_1[logic_new_func_x_2] ^ hoisted_4_1[logic_new_func_x_2];
           end ) );
-    deduped_69_1 := [ 0 .. Length( deduped_76_1 ) - 1 ];
-    deduped_68_1 := [ 0 .. Product( deduped_74_1 ) - 1 ];
+    deduped_69_1 := [ 0 .. Product( deduped_74_1 ) - 1 ];
+    deduped_68_1 := [ 0 .. Length( deduped_76_1 ) - 1 ];
     deduped_67_1 := [ 0 .. Product( deduped_71_1 ) - 1 ];
     deduped_66_1 := [ 0 .. Product( deduped_70_1 ) - 1 ];
-    hoisted_32_1 := List( deduped_81_1, AsList );
-    hoisted_31_1 := List( deduped_81_1, function ( logic_new_func_x_2 )
+    hoisted_32_1 := List( deduped_84_1, AsList );
+    hoisted_31_1 := List( deduped_84_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_30_1 := List( deduped_82_1, AsList );
-    hoisted_29_1 := List( deduped_82_1, function ( logic_new_func_x_2 )
+    hoisted_30_1 := List( deduped_85_1, AsList );
+    hoisted_29_1 := List( deduped_85_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
     hoisted_24_1 := deduped_67_1;
@@ -319,7 +321,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_15_1 := deduped_85_1;
+    hoisted_15_1 := deduped_81_1;
     hoisted_33_1 := Concatenation( List( deduped_75_1, function ( logic_new_func_x_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, hoisted_7_2, hoisted_8_2, hoisted_9_2, hoisted_10_2, deduped_11_2, deduped_12_2, deduped_13_2, deduped_14_2, deduped_15_2;
               deduped_15_2 := hoisted_31_1[logic_new_func_x_2];
@@ -355,7 +357,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                           return hoisted_10_2[1 + hoisted_9_2[(1 + i_3)]];
                       end ) ];
           end ) );
-    hoisted_7_1 := deduped_80_1;
+    hoisted_7_1 := deduped_78_1;
     hoisted_27_1 := Concatenation( List( deduped_75_1, function ( logic_new_func_x_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_23_1[1 + (hoisted_7_1 + logic_new_func_x_2)];
@@ -383,12 +385,12 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                       return hoisted_33_1[deduped_1_3][hoisted_1_2] * hoisted_28_1[deduped_1_3];
                   end );
         end );
-    hoisted_17_1 := List( deduped_78_1, AsList );
-    hoisted_16_1 := List( deduped_78_1, function ( logic_new_func_x_2 )
+    hoisted_17_1 := List( deduped_82_1, AsList );
+    hoisted_16_1 := List( deduped_82_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_14_1 := List( deduped_79_1, AsList );
-    hoisted_13_1 := List( deduped_79_1, function ( logic_new_func_x_2 )
+    hoisted_14_1 := List( deduped_83_1, AsList );
+    hoisted_13_1 := List( deduped_83_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
     hoisted_6_1 := deduped_66_1;
@@ -466,11 +468,11 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
     deduped_62_1 := Length( deduped_64_1 );
     deduped_61_1 := [ 0 .. deduped_63_1 - 1 ];
     deduped_60_1 := [ 0 .. deduped_62_1 - 1 ];
-    hoisted_39_1 := deduped_69_1;
+    hoisted_39_1 := deduped_68_1;
     hoisted_37_1 := List( deduped_76_1, function ( logic_new_func_x_2 )
             return hoisted_23_1[1 + logic_new_func_x_2];
         end );
-    hoisted_38_1 := List( deduped_69_1, function ( j_2 )
+    hoisted_38_1 := List( deduped_68_1, function ( j_2 )
             return Product( hoisted_37_1{[ 1 .. j_2 ]} );
         end );
     hoisted_35_1 := deduped_61_1;
@@ -499,18 +501,18 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
     hoisted_43_1 := List( deduped_93_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_50_1 := List( deduped_83_1, function ( logic_new_func_x_2 )
+    hoisted_50_1 := List( deduped_79_1, function ( logic_new_func_x_2 )
             return hoisted_46_1[logic_new_func_x_2] ^ hoisted_43_1[logic_new_func_x_2];
         end );
     hoisted_51_1 := List( deduped_76_1, function ( j_2 )
             return Product( hoisted_50_1{[ 1 .. j_2 ]} );
         end );
-    hoisted_48_1 := deduped_68_1;
+    hoisted_48_1 := deduped_69_1;
     hoisted_47_1 := deduped_74_1;
     hoisted_45_1 := List( deduped_93_1, AsList );
     hoisted_44_1 := List( deduped_92_1, AsList );
-    hoisted_42_1 := deduped_83_1;
-    hoisted_49_1 := List( deduped_83_1, function ( logic_new_func_x_2 )
+    hoisted_42_1 := deduped_79_1;
+    hoisted_49_1 := List( deduped_79_1, function ( logic_new_func_x_2 )
             local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, hoisted_7_2, hoisted_8_2, hoisted_9_2, deduped_10_2, deduped_11_2, deduped_12_2, deduped_13_2;
             deduped_13_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_42_1[logic_new_func_x_2] );
             deduped_12_2 := hoisted_41_1[deduped_13_2];
@@ -537,7 +539,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                     return hoisted_9_2[1 + REM_INT( QUO_INT( logic_new_func_x_3, hoisted_7_2 ), hoisted_8_2 )];
                 end );
         end );
-    hoisted_58_1 := List( deduped_68_1, function ( i_2 )
+    hoisted_58_1 := List( deduped_69_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := 1 + i_2;
             return Sum( hoisted_52_1, function ( j_3 )
@@ -549,7 +551,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
     hoisted_56_1 := List( deduped_76_1, function ( logic_new_func_x_2 )
             return hoisted_5_1[1 + logic_new_func_x_2];
         end );
-    hoisted_57_1 := List( deduped_69_1, function ( j_2 )
+    hoisted_57_1 := List( deduped_68_1, function ( j_2 )
             return Product( hoisted_56_1{[ 1 .. j_2 ]} );
         end );
     hoisted_54_1 := deduped_60_1;
@@ -562,7 +564,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                     return REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_6_1[1 + hoisted_53_1[(1 + i_3)]] ), hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    return CreateCapCategoryMorphismWithAttributes( deduped_90_1, CreateCapCategoryObjectWithAttributes( deduped_90_1, Length, deduped_62_1 ), CreateCapCategoryObjectWithAttributes( deduped_90_1, Length, deduped_63_1 ), AsList, List( deduped_60_1, function ( x_2 )
+    return CreateCapCategoryMorphismWithAttributes( deduped_91_1, CreateCapCategoryObjectWithAttributes( deduped_91_1, Length, deduped_62_1 ), CreateCapCategoryObjectWithAttributes( deduped_91_1, Length, deduped_63_1 ), AsList, List( deduped_60_1, function ( x_2 )
               local hoisted_1_2;
               hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_54_1[(1 + x_2)] );
               return -1 + SafePosition( hoisted_59_1, hoisted_58_1[(1 + Sum( hoisted_39_1, function ( j_3 )
@@ -580,45 +582,45 @@ end
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
         
 ########
-function ( cat_1, arg2_1, arg3_1, arg4_1 )
+function ( cat_1, source_1, range_1, alpha_1 )
     local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1;
-    deduped_47_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_46_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_45_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_44_1 := deduped_45_1[2];
-    deduped_43_1 := deduped_46_1[2];
-    deduped_42_1 := deduped_47_1[2];
-    deduped_41_1 := Length( Source( arg4_1 ) );
-    deduped_40_1 := deduped_47_1[1];
-    deduped_39_1 := deduped_46_1[1];
-    deduped_38_1 := deduped_45_1[1];
+    deduped_47_1 := ValuesOfPreSheaf( range_1 );
+    deduped_46_1 := ValuesOfPreSheaf( source_1 );
+    deduped_45_1 := deduped_46_1[2];
+    deduped_44_1 := deduped_47_1[2];
+    deduped_43_1 := Length( Source( alpha_1 ) );
+    deduped_42_1 := deduped_47_1[1];
+    deduped_41_1 := deduped_46_1[1];
+    deduped_40_1 := DefiningPairOfUnderlyingQuiver( Source( cat_1 ) );
+    deduped_39_1 := deduped_40_1[2];
+    deduped_38_1 := deduped_40_1[1];
     deduped_37_1 := [ 1 .. deduped_38_1 ];
     deduped_36_1 := deduped_38_1 - 1;
-    deduped_35_1 := Length( deduped_44_1 );
+    deduped_35_1 := Length( deduped_39_1 );
     deduped_34_1 := [ 0 .. deduped_36_1 ];
     deduped_33_1 := [ 1 .. deduped_35_1 ];
     deduped_32_1 := [ 0 .. deduped_35_1 * 2 - 1 ];
-    hoisted_7_1 := List( deduped_43_1, function ( logic_new_func_x_2 )
+    hoisted_7_1 := List( deduped_45_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_6_1 := List( deduped_42_1, function ( logic_new_func_x_2 )
+    hoisted_6_1 := List( deduped_44_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_5_1 := List( deduped_40_1, Length );
-    hoisted_3_1 := List( deduped_39_1, Length );
+    hoisted_5_1 := List( deduped_42_1, Length );
+    hoisted_3_1 := List( deduped_41_1, Length );
     deduped_31_1 := Concatenation( List( deduped_37_1, function ( logic_new_func_x_2 )
               return hoisted_5_1[logic_new_func_x_2] ^ hoisted_3_1[logic_new_func_x_2];
           end ), List( deduped_33_1, function ( logic_new_func_x_2 )
               return hoisted_6_1[logic_new_func_x_2] ^ hoisted_7_1[logic_new_func_x_2];
           end ) );
     deduped_30_1 := [ 0 .. Product( deduped_31_1 ) - 1 ];
-    hoisted_20_1 := List( deduped_42_1, AsList );
-    hoisted_19_1 := List( deduped_42_1, function ( logic_new_func_x_2 )
+    hoisted_20_1 := List( deduped_44_1, AsList );
+    hoisted_19_1 := List( deduped_44_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_18_1 := deduped_44_1;
-    hoisted_17_1 := List( deduped_43_1, AsList );
-    hoisted_16_1 := List( deduped_43_1, function ( logic_new_func_x_2 )
+    hoisted_18_1 := deduped_39_1;
+    hoisted_17_1 := List( deduped_45_1, AsList );
+    hoisted_16_1 := List( deduped_45_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
     hoisted_9_1 := deduped_30_1;
@@ -698,8 +700,8 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
     hoisted_27_1 := List( deduped_34_1, function ( logic_new_func_x_2 )
             return hoisted_8_1[1 + logic_new_func_x_2];
         end );
-    hoisted_25_1 := [ 0 .. deduped_41_1 - 1 ];
-    hoisted_24_1 := AsList( arg4_1 );
+    hoisted_25_1 := [ 0 .. deduped_43_1 - 1 ];
+    hoisted_24_1 := AsList( alpha_1 );
     hoisted_23_1 := [ 0 .. Length( deduped_29_1 ) - 1 ];
     hoisted_22_1 := deduped_29_1;
     hoisted_26_1 := List( deduped_34_1, function ( logic_new_func_x_2 )
@@ -713,10 +715,10 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
                     return hoisted_3_2[1 + hoisted_24_1[(1 + i_3)]];
                 end );
         end );
-    hoisted_4_1 := deduped_41_1;
-    hoisted_2_1 := deduped_40_1;
-    hoisted_1_1 := deduped_39_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, List( deduped_37_1, function ( i_2 )
+    hoisted_4_1 := deduped_43_1;
+    hoisted_2_1 := deduped_42_1;
+    hoisted_1_1 := deduped_41_1;
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, ValuesOnAllObjects, List( deduped_37_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, hoisted_7_2, hoisted_8_2, deduped_9_2, deduped_10_2, deduped_11_2, deduped_12_2;
               deduped_12_2 := hoisted_5_1[i_2];
               deduped_11_2 := hoisted_3_1[i_2];
@@ -753,40 +755,40 @@ function ( cat_1, arg2_1, arg3_1 )
     local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1;
     deduped_47_1 := ValuesOfPreSheaf( arg2_1 );
     deduped_46_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_45_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_44_1 := deduped_47_1[2];
-    deduped_43_1 := deduped_46_1[2];
-    deduped_42_1 := deduped_47_1[1];
-    deduped_41_1 := deduped_46_1[1];
-    deduped_40_1 := deduped_45_1[2];
-    deduped_39_1 := deduped_45_1[1];
+    deduped_45_1 := deduped_47_1[2];
+    deduped_44_1 := deduped_46_1[2];
+    deduped_43_1 := deduped_47_1[1];
+    deduped_42_1 := deduped_46_1[1];
+    deduped_41_1 := DefiningPairOfUnderlyingQuiver( Source( cat_1 ) );
+    deduped_40_1 := deduped_41_1[2];
+    deduped_39_1 := deduped_41_1[1];
     deduped_38_1 := [ 1 .. deduped_39_1 ];
     deduped_37_1 := deduped_39_1 - 1;
     deduped_36_1 := Length( deduped_40_1 );
     deduped_35_1 := [ 0 .. deduped_37_1 ];
     deduped_34_1 := [ 1 .. deduped_36_1 ];
     deduped_33_1 := [ 0 .. deduped_36_1 * 2 - 1 ];
-    hoisted_4_1 := List( deduped_44_1, function ( logic_new_func_x_2 )
+    hoisted_4_1 := List( deduped_45_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_3_1 := List( deduped_43_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := List( deduped_44_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_2_1 := List( deduped_42_1, Length );
-    hoisted_1_1 := List( deduped_41_1, Length );
+    hoisted_2_1 := List( deduped_43_1, Length );
+    hoisted_1_1 := List( deduped_42_1, Length );
     deduped_32_1 := Concatenation( List( deduped_38_1, function ( logic_new_func_x_2 )
               return hoisted_1_1[logic_new_func_x_2] ^ hoisted_2_1[logic_new_func_x_2];
           end ), List( deduped_34_1, function ( logic_new_func_x_2 )
               return hoisted_3_1[logic_new_func_x_2] ^ hoisted_4_1[logic_new_func_x_2];
           end ) );
     deduped_31_1 := [ 0 .. Product( deduped_32_1 ) - 1 ];
-    hoisted_17_1 := List( deduped_43_1, AsList );
-    hoisted_16_1 := List( deduped_43_1, function ( logic_new_func_x_2 )
+    hoisted_17_1 := List( deduped_44_1, AsList );
+    hoisted_16_1 := List( deduped_44_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
     hoisted_15_1 := deduped_40_1;
-    hoisted_14_1 := List( deduped_44_1, AsList );
-    hoisted_13_1 := List( deduped_44_1, function ( logic_new_func_x_2 )
+    hoisted_14_1 := List( deduped_45_1, AsList );
+    hoisted_13_1 := List( deduped_45_1, function ( logic_new_func_x_2 )
             return Length( Range( logic_new_func_x_2 ) );
         end );
     hoisted_6_1 := deduped_31_1;
@@ -873,8 +875,8 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_23_1 := deduped_30_1;
     hoisted_22_1 := deduped_29_1;
     hoisted_21_1 := deduped_28_1;
-    hoisted_20_1 := deduped_41_1;
-    hoisted_19_1 := deduped_42_1;
+    hoisted_20_1 := deduped_42_1;
+    hoisted_19_1 := deduped_43_1;
     return List( deduped_28_1, function ( logic_new_func_x_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_21_1[1 + logic_new_func_x_2] );

--- a/gap/precompiled_categories/PreSheavesOfAlgebroidWithRelationsInCategoryOfRowsPrecompiled.gi
+++ b/gap/precompiled_categories/PreSheavesOfAlgebroidWithRelationsInCategoryOfRowsPrecompiled.gi
@@ -17,7 +17,7 @@ function ( cat_1, a_1, b_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_6_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] + hoisted_4_1[o_2] );
           end ) );
 end
@@ -38,7 +38,7 @@ function ( cat_1, a_1 )
         end );
     hoisted_2_1 := List( deduped_5_1, Range );
     hoisted_1_1 := List( deduped_5_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] );
           end ) );
 end
@@ -51,24 +51,25 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1;
-    deduped_41_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_40_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_39_1 := SetOfObjects( cat_1 );
-    deduped_38_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_37_1 := Range( cat_1 );
-    deduped_36_1 := deduped_41_1[1];
-    deduped_35_1 := deduped_40_1[1];
-    deduped_34_1 := deduped_41_1[2];
-    deduped_33_1 := deduped_40_1[2];
-    deduped_32_1 := Length( deduped_39_1 );
-    deduped_31_1 := UnderlyingRing( deduped_37_1 );
-    deduped_30_1 := [ 1 .. deduped_32_1 ];
-    deduped_29_1 := [ 1 .. Length( deduped_38_1 ) ];
-    hoisted_2_1 := List( deduped_34_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1;
+    deduped_42_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_41_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_40_1 := Source( cat_1 );
+    deduped_39_1 := Range( cat_1 );
+    deduped_38_1 := deduped_42_1[1];
+    deduped_37_1 := deduped_41_1[1];
+    deduped_36_1 := deduped_42_1[2];
+    deduped_35_1 := deduped_41_1[2];
+    deduped_34_1 := SetOfObjects( deduped_40_1 );
+    deduped_33_1 := SetOfGeneratingMorphisms( deduped_40_1 );
+    deduped_32_1 := UnderlyingRing( deduped_39_1 );
+    deduped_31_1 := Length( deduped_34_1 );
+    deduped_30_1 := [ 1 .. deduped_31_1 ];
+    deduped_29_1 := [ 1 .. Length( deduped_33_1 ) ];
+    hoisted_2_1 := List( deduped_36_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_33_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_35_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
     deduped_28_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
@@ -77,17 +78,17 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_13_1 := deduped_29_1;
     hoisted_12_1 := deduped_28_1;
     hoisted_11_1 := deduped_30_1;
-    hoisted_10_1 := List( deduped_34_1, UnderlyingMatrix );
-    hoisted_9_1 := deduped_31_1;
-    hoisted_8_1 := List( deduped_33_1, function ( logic_new_func_x_2 )
+    hoisted_10_1 := List( deduped_36_1, UnderlyingMatrix );
+    hoisted_9_1 := deduped_32_1;
+    hoisted_8_1 := List( deduped_35_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_38_1, Range );
-    hoisted_6_1 := List( deduped_38_1, Source );
-    hoisted_5_1 := deduped_39_1;
-    hoisted_4_1 := List( deduped_36_1, RankOfObject );
-    hoisted_3_1 := List( deduped_35_1, RankOfObject );
-    deduped_27_1 := SyzygiesOfRows( UnionOfRows( deduped_31_1, Sum( deduped_28_1 ), List( deduped_30_1, function ( logic_new_func_x_2 )
+    hoisted_7_1 := List( deduped_33_1, Range );
+    hoisted_6_1 := List( deduped_33_1, Source );
+    hoisted_5_1 := deduped_34_1;
+    hoisted_4_1 := List( deduped_38_1, RankOfObject );
+    hoisted_3_1 := List( deduped_37_1, RankOfObject );
+    deduped_27_1 := SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_28_1 ), List( deduped_30_1, function ( logic_new_func_x_2 )
                 local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                 deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                 deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -117,16 +118,16 @@ function ( cat_1, arg2_1, arg3_1 )
     deduped_26_1 := NumberRows( deduped_27_1 );
     deduped_25_1 := 1 * deduped_26_1;
     deduped_24_1 := [ 1 .. deduped_25_1 ];
-    hoisted_23_1 := deduped_37_1;
+    hoisted_23_1 := deduped_39_1;
     hoisted_21_1 := deduped_24_1;
     hoisted_20_1 := deduped_27_1;
-    hoisted_19_1 := deduped_32_1;
+    hoisted_19_1 := deduped_31_1;
     hoisted_18_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
             return hoisted_3_1[logic_new_func_x_2] * hoisted_4_1[logic_new_func_x_2];
         end );
     hoisted_17_1 := deduped_26_1;
-    hoisted_16_1 := HomalgIdentityMatrix( deduped_25_1, deduped_31_1 );
-    hoisted_22_1 := List( [ 1 .. Length( deduped_35_1 ) ], function ( logic_new_func_x_2 )
+    hoisted_16_1 := HomalgIdentityMatrix( deduped_25_1, deduped_32_1 );
+    hoisted_22_1 := List( [ 1 .. Length( deduped_37_1 ) ], function ( logic_new_func_x_2 )
             local hoisted_1_2, deduped_2_2;
             deduped_2_2 := hoisted_18_1[logic_new_func_x_2];
             hoisted_1_2 := hoisted_20_1 * UnionOfRows( HomalgZeroMatrix( Sum( hoisted_18_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), deduped_2_2, hoisted_9_1 ), HomalgIdentityMatrix( deduped_2_2, hoisted_9_1 ), HomalgZeroMatrix( Sum( hoisted_18_1{[ (logic_new_func_x_2 + 1) .. hoisted_19_1 ]} ), deduped_2_2, hoisted_9_1 ) );
@@ -134,8 +135,8 @@ function ( cat_1, arg2_1, arg3_1 )
                     return ConvertRowToMatrix( CertainRows( hoisted_16_1, [ logic_new_func_x_3 ] ), 1, hoisted_17_1 ) * hoisted_1_2;
                 end );
         end );
-    hoisted_15_1 := deduped_36_1;
-    hoisted_14_1 := deduped_35_1;
+    hoisted_15_1 := deduped_38_1;
+    hoisted_14_1 := deduped_37_1;
     return List( deduped_24_1, function ( j_2 )
             return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, LazyHList( hoisted_11_1, function ( i_3 )
                       return CreateCapCategoryMorphismWithAttributes( hoisted_23_1, hoisted_14_1[i_3], hoisted_15_1[i_3], UnderlyingMatrix, ConvertRowToMatrix( hoisted_22_1[i_3][j_2], hoisted_3_1[i_3], hoisted_4_1[i_3] ) );
@@ -167,7 +168,7 @@ function ( cat_1, alpha_1, I_1 )
         end );
     hoisted_2_1 := List( deduped_8_1, UnderlyingMatrix );
     hoisted_1_1 := List( deduped_8_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), I_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), I_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := RightDivide( hoisted_2_1[o_2], HomalgIdentityMatrix( (hoisted_3_1[o_2] - hoisted_4_1[o_2]), hoisted_5_1 ) * hoisted_6_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_7_1, hoisted_1_1[o_2], CreateCapCategoryObjectWithAttributes( hoisted_7_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -182,41 +183,42 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1;
-    deduped_23_1 := SetOfObjects( cat_1 );
-    deduped_22_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_21_1 := ValuesOfPreSheaf( Range( arg2_1 ) );
-    deduped_20_1 := ValuesOfPreSheaf( Source( arg2_1 ) );
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1;
+    deduped_24_1 := Source( cat_1 );
+    deduped_23_1 := ValuesOfPreSheaf( Range( arg2_1 ) );
+    deduped_22_1 := ValuesOfPreSheaf( Source( arg2_1 ) );
+    deduped_21_1 := SetOfObjects( deduped_24_1 );
+    deduped_20_1 := SetOfGeneratingMorphisms( deduped_24_1 );
     deduped_19_1 := UnderlyingRing( Range( cat_1 ) );
-    deduped_18_1 := [ 1 .. Length( deduped_23_1 ) ];
-    deduped_17_1 := [ 1 .. Length( deduped_22_1 ) ];
-    deduped_16_1 := deduped_21_1[2];
-    deduped_15_1 := deduped_20_1[2];
-    hoisted_2_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
+    deduped_18_1 := deduped_23_1[2];
+    deduped_17_1 := deduped_22_1[2];
+    deduped_16_1 := [ 1 .. Length( deduped_21_1 ) ];
+    deduped_15_1 := [ 1 .. Length( deduped_20_1 ) ];
+    hoisted_2_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_15_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_14_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
+    deduped_14_1 := List( deduped_15_1, function ( logic_new_func_x_2 )
             return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
         end );
-    hoisted_13_1 := deduped_17_1;
+    hoisted_13_1 := deduped_15_1;
     hoisted_12_1 := deduped_14_1;
-    hoisted_11_1 := deduped_18_1;
-    hoisted_10_1 := List( deduped_16_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_16_1;
+    hoisted_10_1 := List( deduped_18_1, UnderlyingMatrix );
     hoisted_9_1 := deduped_19_1;
-    hoisted_8_1 := List( deduped_15_1, function ( logic_new_func_x_2 )
+    hoisted_8_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_22_1, Range );
-    hoisted_6_1 := List( deduped_22_1, Source );
-    hoisted_5_1 := deduped_23_1;
-    hoisted_4_1 := List( deduped_21_1[1], RankOfObject );
-    hoisted_3_1 := List( deduped_20_1[1], RankOfObject );
+    hoisted_7_1 := List( deduped_20_1, Range );
+    hoisted_6_1 := List( deduped_20_1, Source );
+    hoisted_5_1 := deduped_21_1;
+    hoisted_4_1 := List( deduped_23_1[1], RankOfObject );
+    hoisted_3_1 := List( deduped_22_1[1], RankOfObject );
     return EntriesOfHomalgMatrix( RightDivide( UnionOfColumns( deduped_19_1, 1, List( ListOfValues( ValuesOnAllObjects( arg2_1 ) ), function ( logic_new_func_x_2 )
                   return ConvertMatrixToRow( UnderlyingMatrix( logic_new_func_x_2 ) );
-              end ) ), SyzygiesOfRows( UnionOfRows( deduped_19_1, Sum( deduped_14_1 ), List( deduped_18_1, function ( logic_new_func_x_2 )
+              end ) ), SyzygiesOfRows( UnionOfRows( deduped_19_1, Sum( deduped_14_1 ), List( deduped_16_1, function ( logic_new_func_x_2 )
                     local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                     deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                     deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -261,7 +263,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
     hoisted_1_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := LeftDivide( hoisted_1_1[o_2], hoisted_2_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_3_1, CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), hoisted_4_1[o_2], UnderlyingMatrix, morphism_attr_1_2 );
@@ -276,24 +278,25 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := ValuesOnAllObjects( arg2_1 );
-    deduped_9_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_8_1 := Range( cat_1 );
-    deduped_7_1 := deduped_9_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
+    deduped_11_1 := ValuesOnAllObjects( arg2_1 );
+    deduped_10_1 := Range( cat_1 );
+    deduped_9_1 := Source( cat_1 );
+    deduped_8_1 := DefiningPairOfUnderlyingQuiver( deduped_9_1 );
+    deduped_7_1 := deduped_8_1[2];
     hoisted_6_1 := List( ValuesOfPreSheaf( Range( arg2_1 ) )[2], UnderlyingMatrix );
-    hoisted_5_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
     hoisted_4_1 := deduped_7_1;
-    hoisted_3_1 := deduped_8_1;
-    hoisted_2_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := deduped_10_1;
+    hoisted_2_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RowRankOfMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_8_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_9_1, Range, deduped_10_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, hoisted_1_1[o_2] - hoisted_2_1[o_2] );
             end ), LazyHList( [ 1 .. Length( deduped_7_1 ) ], function ( m_2 )
                 local morphism_attr_1_2, deduped_2_2;
@@ -320,7 +323,7 @@ function ( cat_1, P_1, alpha_1, mu_1, alphap_1, Pp_1 )
     hoisted_1_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := LeftDivide( hoisted_1_1[o_2], hoisted_2_1[o_2] * hoisted_3_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -342,7 +345,7 @@ function ( cat_1, alpha_1, P_1 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
     hoisted_1_1 := List( deduped_4_1, Range );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := hoisted_2_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_3_1, hoisted_1_1[o_2], CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -365,7 +368,7 @@ function ( cat_1, epsilon_1, tau_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := List( deduped_6_1, Range );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( epsilon_1 ), Range( tau_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( epsilon_1 ), Range( tau_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, LeftDivide( hoisted_3_1[o_2], hoisted_4_1[o_2] ) );
           end ) );
 end
@@ -386,7 +389,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
     hoisted_3_1 := List( deduped_7_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_6_1 ) )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( S_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -412,7 +415,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
     hoisted_3_1 := List( deduped_7_1, UnderlyingMatrix );
     hoisted_2_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_6_1 ) )[1];
     hoisted_1_1 := List( deduped_7_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( S_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -430,17 +433,18 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
-    deduped_9_1 := Length( arg2_1 );
-    deduped_8_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_7_1 := Range( cat_1 );
-    deduped_6_1 := deduped_8_1[2];
-    hoisted_5_1 := [ 1 .. deduped_9_1 ];
-    hoisted_4_1 := deduped_9_1;
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := Length( arg2_1 );
+    deduped_9_1 := Range( cat_1 );
+    deduped_8_1 := Source( cat_1 );
+    deduped_7_1 := DefiningPairOfUnderlyingQuiver( deduped_8_1 );
+    deduped_6_1 := deduped_7_1[2];
+    hoisted_5_1 := [ 1 .. deduped_10_1 ];
+    hoisted_4_1 := deduped_10_1;
     hoisted_3_1 := deduped_6_1;
-    hoisted_2_1 := UnderlyingRing( deduped_7_1 );
-    hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_7_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
+    hoisted_2_1 := UnderlyingRing( deduped_9_1 );
+    hoisted_1_1 := deduped_9_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_8_1, Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_7_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_1_1, RankOfObject, Sum( List( arg2_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
                         end ) ) );
@@ -485,7 +489,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
     hoisted_3_1 := Length( objectsp_1 );
     hoisted_2_1 := List( deduped_7_1, RankOfObject );
     hoisted_1_1 := UnderlyingRing( deduped_8_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
               deduped_5_2 := List( objectsp_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -514,17 +518,18 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
-    deduped_9_1 := Length( arg2_1 );
-    deduped_8_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_7_1 := Range( cat_1 );
-    deduped_6_1 := deduped_8_1[2];
-    hoisted_5_1 := [ 1 .. deduped_9_1 ];
-    hoisted_4_1 := deduped_9_1;
-    hoisted_3_1 := UnderlyingRing( deduped_7_1 );
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := Length( arg2_1 );
+    deduped_9_1 := Range( cat_1 );
+    deduped_8_1 := Source( cat_1 );
+    deduped_7_1 := DefiningPairOfUnderlyingQuiver( deduped_8_1 );
+    deduped_6_1 := deduped_7_1[2];
+    hoisted_5_1 := [ 1 .. deduped_10_1 ];
+    hoisted_4_1 := deduped_10_1;
+    hoisted_3_1 := UnderlyingRing( deduped_9_1 );
     hoisted_2_1 := deduped_6_1;
-    hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_7_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
+    hoisted_1_1 := deduped_9_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_8_1, Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_7_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_1_1, RankOfObject, Sum( List( arg2_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
                         end ) ) );
@@ -569,7 +574,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
     hoisted_3_1 := UnderlyingRing( deduped_8_1 );
     hoisted_2_1 := List( deduped_7_1, RankOfObject );
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
               deduped_5_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -598,16 +603,17 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_3_1 := Range( cat_1 );
-    hoisted_2_1 := UnderlyingRing( deduped_3_1 );
-    hoisted_1_1 := deduped_3_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_3_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
+    deduped_5_1 := Range( cat_1 );
+    deduped_4_1 := Source( cat_1 );
+    deduped_3_1 := DefiningPairOfUnderlyingQuiver( deduped_4_1 );
+    hoisted_2_1 := UnderlyingRing( deduped_5_1 );
+    hoisted_1_1 := deduped_5_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_4_1, Range, deduped_5_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_3_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_1_1, RankOfObject, Sum( List( arg2_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
                         end ) ) );
-            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_3_1[2] ) ], function ( m_2 )
                 local deduped_1_2;
                 deduped_1_2 := DiagMat( hoisted_2_1, List( arg2_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[2][m_2] ) );
@@ -630,7 +636,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
     hoisted_3_1 := UnderlyingRing( deduped_5_1 );
     hoisted_2_1 := ValuesOfPreSheaf( Pp_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, DiagMat( hoisted_3_1, List( L_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
                       end ) ) );
@@ -656,19 +662,20 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
-    deduped_11_1 := Length( arg2_1 );
-    deduped_10_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_9_1 := Range( cat_1 );
-    deduped_8_1 := deduped_10_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
+    deduped_12_1 := Length( arg2_1 );
+    deduped_11_1 := Range( cat_1 );
+    deduped_10_1 := Source( cat_1 );
+    deduped_9_1 := DefiningPairOfUnderlyingQuiver( deduped_10_1 );
+    deduped_8_1 := deduped_9_1[2];
     hoisted_7_1 := deduped_8_1;
-    hoisted_6_1 := deduped_9_1;
-    hoisted_5_1 := [ 2 .. deduped_11_1 ];
-    hoisted_4_1 := [ 1 .. deduped_11_1 - 1 ];
-    hoisted_3_1 := [ 1 .. deduped_11_1 ];
-    hoisted_2_1 := deduped_11_1;
-    hoisted_1_1 := UnderlyingRing( deduped_9_1 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_10_1[1] ], function ( o_2 )
+    hoisted_6_1 := deduped_11_1;
+    hoisted_5_1 := [ 2 .. deduped_12_1 ];
+    hoisted_4_1 := [ 1 .. deduped_12_1 - 1 ];
+    hoisted_3_1 := [ 1 .. deduped_12_1 ];
+    hoisted_2_1 := deduped_12_1;
+    hoisted_1_1 := UnderlyingRing( deduped_11_1 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_10_1, Range, deduped_11_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
                 local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
                 deduped_5_2 := List( arg2_1, function ( logic_new_func_x_3 )
                         return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -757,7 +764,7 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
     hoisted_3_1 := UnderlyingRing( deduped_15_1 );
     hoisted_2_1 := List( deduped_14_1, RankOfObject );
     hoisted_1_1 := deduped_14_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2, deduped_11_2, deduped_12_2, deduped_13_2, deduped_14_2, deduped_15_2;
               deduped_15_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -808,64 +815,65 @@ end
         
 ########
 function ( cat_1, source_1, alpha_1, beta_1, range_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1;
-    deduped_39_1 := SetOfObjects( cat_1 );
-    deduped_38_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_37_1 := Range( cat_1 );
-    deduped_36_1 := ValuesOfPreSheaf( Range( beta_1 ) );
-    deduped_35_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
-    deduped_34_1 := ValuesOfPreSheaf( Source( beta_1 ) );
-    deduped_33_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
-    deduped_32_1 := UnderlyingRing( deduped_37_1 );
-    deduped_31_1 := [ 1 .. Length( deduped_39_1 ) ];
-    deduped_30_1 := [ 1 .. Length( deduped_38_1 ) ];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1;
+    deduped_40_1 := Source( cat_1 );
+    deduped_39_1 := Range( cat_1 );
+    deduped_38_1 := ValuesOfPreSheaf( Range( beta_1 ) );
+    deduped_37_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
+    deduped_36_1 := ValuesOfPreSheaf( Source( beta_1 ) );
+    deduped_35_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
+    deduped_34_1 := SetOfObjects( deduped_40_1 );
+    deduped_33_1 := SetOfGeneratingMorphisms( deduped_40_1 );
+    deduped_32_1 := UnderlyingRing( deduped_39_1 );
+    deduped_31_1 := deduped_38_1[2];
+    deduped_30_1 := deduped_37_1[2];
     deduped_29_1 := deduped_36_1[2];
     deduped_28_1 := deduped_35_1[2];
-    deduped_27_1 := deduped_34_1[2];
-    deduped_26_1 := deduped_33_1[2];
-    hoisted_17_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
+    deduped_27_1 := [ 1 .. Length( deduped_34_1 ) ];
+    deduped_26_1 := [ 1 .. Length( deduped_33_1 ) ];
+    hoisted_17_1 := List( deduped_31_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_16_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
+    hoisted_16_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_25_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
+    deduped_25_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
             return hoisted_16_1[logic_new_func_x_2] * hoisted_17_1[logic_new_func_x_2];
         end );
-    hoisted_2_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_2_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_24_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
+    deduped_24_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
             return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
         end );
     hoisted_22_1 := deduped_25_1;
-    hoisted_21_1 := List( deduped_29_1, UnderlyingMatrix );
-    hoisted_20_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
+    hoisted_21_1 := List( deduped_31_1, UnderlyingMatrix );
+    hoisted_20_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_19_1 := List( deduped_36_1[1], RankOfObject );
-    hoisted_18_1 := List( deduped_35_1[1], RankOfObject );
+    hoisted_19_1 := List( deduped_38_1[1], RankOfObject );
+    hoisted_18_1 := List( deduped_37_1[1], RankOfObject );
     hoisted_15_1 := List( ValuesOnAllObjects( beta_1 ), UnderlyingMatrix );
     hoisted_14_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_13_1 := deduped_30_1;
+    hoisted_13_1 := deduped_26_1;
     hoisted_12_1 := deduped_24_1;
-    hoisted_11_1 := deduped_31_1;
-    hoisted_10_1 := List( deduped_27_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_27_1;
+    hoisted_10_1 := List( deduped_29_1, UnderlyingMatrix );
     hoisted_9_1 := deduped_32_1;
-    hoisted_8_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
+    hoisted_8_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_38_1, Range );
-    hoisted_6_1 := List( deduped_38_1, Source );
-    hoisted_5_1 := deduped_39_1;
-    hoisted_4_1 := List( deduped_34_1[1], RankOfObject );
-    hoisted_3_1 := List( deduped_33_1[1], RankOfObject );
-    deduped_23_1 := RightDivide( SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_24_1 ), List( deduped_31_1, function ( logic_new_func_x_2 )
+    hoisted_7_1 := List( deduped_33_1, Range );
+    hoisted_6_1 := List( deduped_33_1, Source );
+    hoisted_5_1 := deduped_34_1;
+    hoisted_4_1 := List( deduped_36_1[1], RankOfObject );
+    hoisted_3_1 := List( deduped_35_1[1], RankOfObject );
+    deduped_23_1 := RightDivide( SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_24_1 ), List( deduped_27_1, function ( logic_new_func_x_2 )
                     local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                     deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                     deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -891,9 +899,9 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                               fi;
                               return;
                           end ) );
-                end ) ) ) * DiagMat( deduped_32_1, List( deduped_31_1, function ( logic_new_func_x_2 )
+                end ) ) ) * DiagMat( deduped_32_1, List( deduped_27_1, function ( logic_new_func_x_2 )
                   return KroneckerMat( hoisted_14_1[logic_new_func_x_2], hoisted_15_1[logic_new_func_x_2] );
-              end ) ), SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_25_1 ), List( deduped_31_1, function ( logic_new_func_x_2 )
+              end ) ), SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_25_1 ), List( deduped_27_1, function ( logic_new_func_x_2 )
                   local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                   deduped_7_2 := hoisted_19_1[logic_new_func_x_2];
                   deduped_6_2 := hoisted_18_1[logic_new_func_x_2];
@@ -920,7 +928,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                             return;
                         end ) );
               end ) ) ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_37_1, CreateCapCategoryObjectWithAttributes( deduped_37_1, RankOfObject, NumberRows( deduped_23_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_37_1, RankOfObject, NumberColumns( deduped_23_1 ) ), UnderlyingMatrix, deduped_23_1 );
+    return CreateCapCategoryMorphismWithAttributes( deduped_39_1, CreateCapCategoryObjectWithAttributes( deduped_39_1, RankOfObject, NumberRows( deduped_23_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_39_1, RankOfObject, NumberColumns( deduped_23_1 ) ), UnderlyingMatrix, deduped_23_1 );
 end
 ########
         
@@ -931,21 +939,22 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1;
-    deduped_24_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_23_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_22_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_21_1 := SetOfObjects( cat_1 );
-    deduped_20_1 := Range( cat_1 );
-    deduped_19_1 := deduped_24_1[2];
-    deduped_18_1 := deduped_23_1[2];
-    deduped_17_1 := UnderlyingRing( deduped_20_1 );
-    deduped_16_1 := [ 1 .. Length( deduped_22_1 ) ];
-    deduped_15_1 := [ 1 .. Length( deduped_21_1 ) ];
-    hoisted_4_1 := List( deduped_19_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1;
+    deduped_25_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_24_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_23_1 := Source( cat_1 );
+    deduped_22_1 := Range( cat_1 );
+    deduped_21_1 := deduped_25_1[2];
+    deduped_20_1 := deduped_24_1[2];
+    deduped_19_1 := SetOfGeneratingMorphisms( deduped_23_1 );
+    deduped_18_1 := UnderlyingRing( deduped_22_1 );
+    deduped_17_1 := SetOfObjects( deduped_23_1 );
+    deduped_16_1 := [ 1 .. Length( deduped_19_1 ) ];
+    deduped_15_1 := [ 1 .. Length( deduped_17_1 ) ];
+    hoisted_4_1 := List( deduped_21_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_3_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := List( deduped_20_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
     deduped_14_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
@@ -954,19 +963,19 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_13_1 := deduped_16_1;
     hoisted_12_1 := deduped_14_1;
     hoisted_11_1 := deduped_15_1;
-    hoisted_10_1 := List( deduped_19_1, UnderlyingMatrix );
-    hoisted_9_1 := deduped_17_1;
-    hoisted_8_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
+    hoisted_10_1 := List( deduped_21_1, UnderlyingMatrix );
+    hoisted_9_1 := deduped_18_1;
+    hoisted_8_1 := List( deduped_20_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_22_1, Range );
-    hoisted_6_1 := List( deduped_22_1, Source );
-    hoisted_5_1 := deduped_21_1;
-    hoisted_2_1 := List( deduped_24_1[1], RankOfObject );
-    hoisted_1_1 := List( deduped_23_1[1], RankOfObject );
-    return CreateCapCategoryObjectWithAttributes( deduped_20_1, RankOfObject, Sum( List( deduped_15_1, function ( logic_new_func_x_2 )
+    hoisted_7_1 := List( deduped_19_1, Range );
+    hoisted_6_1 := List( deduped_19_1, Source );
+    hoisted_5_1 := deduped_17_1;
+    hoisted_2_1 := List( deduped_25_1[1], RankOfObject );
+    hoisted_1_1 := List( deduped_24_1[1], RankOfObject );
+    return CreateCapCategoryObjectWithAttributes( deduped_22_1, RankOfObject, Sum( List( deduped_15_1, function ( logic_new_func_x_2 )
                   return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
-              end ) ) - RowRankOfMatrix( UnionOfRows( deduped_17_1, Sum( deduped_14_1 ), List( deduped_15_1, function ( logic_new_func_x_2 )
+              end ) ) - RowRankOfMatrix( UnionOfRows( deduped_18_1, Sum( deduped_14_1 ), List( deduped_15_1, function ( logic_new_func_x_2 )
                     local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                     deduped_7_2 := hoisted_2_1[logic_new_func_x_2];
                     deduped_6_2 := hoisted_1_1[logic_new_func_x_2];
@@ -1010,7 +1019,7 @@ function ( cat_1, a_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -1040,7 +1049,7 @@ function ( cat_1, alpha_1, I_1 )
     hoisted_1_1 := List( deduped_7_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := HomalgIdentityMatrix( (hoisted_1_1[o_2] - hoisted_2_1[o_2]), hoisted_3_1 ) * hoisted_4_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CreateCapCategoryObjectWithAttributes( hoisted_5_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), hoisted_6_1[o_2], UnderlyingMatrix, morphism_attr_1_2 );
@@ -1055,25 +1064,26 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
-    deduped_11_1 := ValuesOnAllObjects( arg2_1 );
-    deduped_10_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_9_1 := Range( cat_1 );
-    deduped_8_1 := deduped_10_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
+    deduped_12_1 := ValuesOnAllObjects( arg2_1 );
+    deduped_11_1 := Range( cat_1 );
+    deduped_10_1 := Source( cat_1 );
+    deduped_9_1 := DefiningPairOfUnderlyingQuiver( deduped_10_1 );
+    deduped_8_1 := deduped_9_1[2];
     hoisted_7_1 := List( ValuesOfPreSheaf( Range( arg2_1 ) )[2], UnderlyingMatrix );
-    hoisted_6_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
+    hoisted_6_1 := List( deduped_12_1, function ( logic_new_func_x_2 )
             return SyzygiesOfRows( SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) ) );
         end );
-    hoisted_5_1 := UnderlyingRing( deduped_9_1 );
+    hoisted_5_1 := UnderlyingRing( deduped_11_1 );
     hoisted_4_1 := deduped_8_1;
-    hoisted_3_1 := deduped_9_1;
-    hoisted_2_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := deduped_11_1;
+    hoisted_2_1 := List( deduped_12_1, function ( logic_new_func_x_2 )
             return RowRankOfMatrix( SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) ) );
         end );
-    hoisted_1_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_12_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_10_1[1] ], function ( o_2 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_10_1, Range, deduped_11_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, hoisted_1_1[o_2] - hoisted_2_1[o_2] );
             end ), LazyHList( [ 1 .. Length( deduped_8_1 ) ], function ( m_2 )
                 local morphism_attr_1_2, deduped_2_2, deduped_3_2, deduped_4_2;
@@ -1093,15 +1103,16 @@ end
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_4_1 ) );
-    hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, RankOfObject, 0 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_6_1 ) );
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, RankOfObject, 0 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := hoisted_3_1;
                 return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, hoisted_1_1, hoisted_1_1, UnderlyingMatrix, morphism_attr_1_2 );
@@ -1124,7 +1135,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := UnderlyingRing( deduped_7_1 );
     hoisted_2_1 := [ 1 .. k_1 - 1 ];
     hoisted_1_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_6_1 ) )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2, deduped_3_2;
               deduped_3_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -1152,7 +1163,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := [ 1 .. k_1 - 1 ];
     hoisted_2_1 := ValuesOfPreSheaf( P_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_7_1 ) )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_7_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_7_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -1182,7 +1193,7 @@ function ( cat_1, morphisms_1, k_1, P_1 )
     hoisted_3_1 := deduped_11_1;
     hoisted_2_1 := UnderlyingRing( deduped_10_1 );
     hoisted_1_1 := ValuesOnAllObjects( deduped_9_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
               deduped_8_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -1212,42 +1223,43 @@ end
         
 ########
 function ( cat_1, alpha_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1;
-    deduped_25_1 := SetOfObjects( cat_1 );
-    deduped_24_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_23_1 := Range( cat_1 );
-    deduped_22_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
-    deduped_21_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
-    deduped_20_1 := UnderlyingRing( deduped_23_1 );
-    deduped_19_1 := [ 1 .. Length( deduped_25_1 ) ];
-    deduped_18_1 := [ 1 .. Length( deduped_24_1 ) ];
-    deduped_17_1 := deduped_22_1[2];
-    deduped_16_1 := deduped_21_1[2];
-    hoisted_2_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1;
+    deduped_26_1 := Source( cat_1 );
+    deduped_25_1 := Range( cat_1 );
+    deduped_24_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
+    deduped_23_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
+    deduped_22_1 := SetOfObjects( deduped_26_1 );
+    deduped_21_1 := SetOfGeneratingMorphisms( deduped_26_1 );
+    deduped_20_1 := UnderlyingRing( deduped_25_1 );
+    deduped_19_1 := deduped_24_1[2];
+    deduped_18_1 := deduped_23_1[2];
+    deduped_17_1 := [ 1 .. Length( deduped_22_1 ) ];
+    deduped_16_1 := [ 1 .. Length( deduped_21_1 ) ];
+    hoisted_2_1 := List( deduped_19_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_15_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
+    deduped_15_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
             return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
         end );
-    hoisted_13_1 := deduped_18_1;
+    hoisted_13_1 := deduped_16_1;
     hoisted_12_1 := deduped_15_1;
-    hoisted_11_1 := deduped_19_1;
-    hoisted_10_1 := List( deduped_17_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_17_1;
+    hoisted_10_1 := List( deduped_19_1, UnderlyingMatrix );
     hoisted_9_1 := deduped_20_1;
-    hoisted_8_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
+    hoisted_8_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_24_1, Range );
-    hoisted_6_1 := List( deduped_24_1, Source );
-    hoisted_5_1 := deduped_25_1;
-    hoisted_4_1 := List( deduped_22_1[1], RankOfObject );
-    hoisted_3_1 := List( deduped_21_1[1], RankOfObject );
+    hoisted_7_1 := List( deduped_21_1, Range );
+    hoisted_6_1 := List( deduped_21_1, Source );
+    hoisted_5_1 := deduped_22_1;
+    hoisted_4_1 := List( deduped_24_1[1], RankOfObject );
+    hoisted_3_1 := List( deduped_23_1[1], RankOfObject );
     deduped_14_1 := RightDivide( UnionOfColumns( deduped_20_1, 1, List( ListOfValues( ValuesOnAllObjects( alpha_1 ) ), function ( logic_new_func_x_2 )
                 return ConvertMatrixToRow( UnderlyingMatrix( logic_new_func_x_2 ) );
-            end ) ), SyzygiesOfRows( UnionOfRows( deduped_20_1, Sum( deduped_15_1 ), List( deduped_19_1, function ( logic_new_func_x_2 )
+            end ) ), SyzygiesOfRows( UnionOfRows( deduped_20_1, Sum( deduped_15_1 ), List( deduped_17_1, function ( logic_new_func_x_2 )
                   local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                   deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                   deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -1274,7 +1286,7 @@ function ( cat_1, alpha_1 )
                             return;
                         end ) );
               end ) ) ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_23_1, CreateCapCategoryObjectWithAttributes( deduped_23_1, RankOfObject, 1 ), CreateCapCategoryObjectWithAttributes( deduped_23_1, RankOfObject, NumberColumns( deduped_14_1 ) ), UnderlyingMatrix, deduped_14_1 );
+    return CreateCapCategoryMorphismWithAttributes( deduped_25_1, CreateCapCategoryObjectWithAttributes( deduped_25_1, RankOfObject, 1 ), CreateCapCategoryObjectWithAttributes( deduped_25_1, RankOfObject, NumberColumns( deduped_14_1 ) ), UnderlyingMatrix, deduped_14_1 );
 end
 ########
         
@@ -1284,45 +1296,46 @@ end
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
         
 ########
-function ( cat_1, arg2_1, arg3_1, arg4_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1;
-    deduped_34_1 := Range( cat_1 );
-    deduped_33_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_32_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_31_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_30_1 := SetOfObjects( cat_1 );
-    deduped_29_1 := UnderlyingRing( deduped_34_1 );
-    deduped_28_1 := deduped_32_1[2];
-    deduped_27_1 := deduped_31_1[2];
-    deduped_26_1 := deduped_32_1[1];
-    deduped_25_1 := deduped_31_1[1];
-    deduped_24_1 := Length( deduped_30_1 );
-    deduped_23_1 := [ 1 .. Length( deduped_33_1 ) ];
+function ( cat_1, source_1, range_1, alpha_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1;
+    deduped_35_1 := Range( cat_1 );
+    deduped_34_1 := ValuesOfPreSheaf( range_1 );
+    deduped_33_1 := ValuesOfPreSheaf( source_1 );
+    deduped_32_1 := Source( cat_1 );
+    deduped_31_1 := UnderlyingRing( deduped_35_1 );
+    deduped_30_1 := SetOfGeneratingMorphisms( deduped_32_1 );
+    deduped_29_1 := deduped_34_1[2];
+    deduped_28_1 := deduped_33_1[2];
+    deduped_27_1 := deduped_34_1[1];
+    deduped_26_1 := deduped_33_1[1];
+    deduped_25_1 := SetOfObjects( deduped_32_1 );
+    deduped_24_1 := Length( deduped_25_1 );
+    deduped_23_1 := [ 1 .. Length( deduped_30_1 ) ];
     deduped_22_1 := [ 1 .. deduped_24_1 ];
-    hoisted_4_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
+    hoisted_4_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_3_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
     deduped_21_1 := List( deduped_23_1, function ( logic_new_func_x_2 )
             return hoisted_3_1[logic_new_func_x_2] * hoisted_4_1[logic_new_func_x_2];
         end );
-    hoisted_20_1 := deduped_34_1;
+    hoisted_20_1 := deduped_35_1;
     hoisted_15_1 := deduped_23_1;
     hoisted_14_1 := deduped_21_1;
     hoisted_13_1 := deduped_22_1;
-    hoisted_12_1 := List( deduped_28_1, UnderlyingMatrix );
-    hoisted_11_1 := deduped_29_1;
-    hoisted_10_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_12_1 := List( deduped_29_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_31_1;
+    hoisted_10_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_9_1 := List( deduped_33_1, Range );
-    hoisted_8_1 := List( deduped_33_1, Source );
-    hoisted_7_1 := deduped_30_1;
-    hoisted_6_1 := List( deduped_26_1, RankOfObject );
-    hoisted_5_1 := List( deduped_25_1, RankOfObject );
-    hoisted_18_1 := UnderlyingMatrix( arg4_1 ) * SyzygiesOfRows( UnionOfRows( deduped_29_1, Sum( deduped_21_1 ), List( deduped_22_1, function ( logic_new_func_x_2 )
+    hoisted_9_1 := List( deduped_30_1, Range );
+    hoisted_8_1 := List( deduped_30_1, Source );
+    hoisted_7_1 := deduped_25_1;
+    hoisted_6_1 := List( deduped_27_1, RankOfObject );
+    hoisted_5_1 := List( deduped_26_1, RankOfObject );
+    hoisted_18_1 := UnderlyingMatrix( alpha_1 ) * SyzygiesOfRows( UnionOfRows( deduped_31_1, Sum( deduped_21_1 ), List( deduped_22_1, function ( logic_new_func_x_2 )
                   local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                   deduped_7_2 := hoisted_6_1[logic_new_func_x_2];
                   deduped_6_2 := hoisted_5_1[logic_new_func_x_2];
@@ -1359,9 +1372,9 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
             deduped_1_2 := hoisted_5_1[deduped_2_2] * hoisted_6_1[deduped_2_2];
             return hoisted_18_1 * UnionOfRows( HomalgZeroMatrix( Sum( hoisted_16_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), deduped_1_2, hoisted_11_1 ), HomalgIdentityMatrix( deduped_1_2, hoisted_11_1 ), HomalgZeroMatrix( Sum( hoisted_16_1{[ (logic_new_func_x_2 + 1) .. hoisted_17_1 ]} ), deduped_1_2, hoisted_11_1 ) );
         end );
-    hoisted_2_1 := deduped_26_1;
-    hoisted_1_1 := deduped_25_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, LazyHList( deduped_22_1, function ( i_2 )
+    hoisted_2_1 := deduped_27_1;
+    hoisted_1_1 := deduped_26_1;
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, ValuesOnAllObjects, LazyHList( deduped_22_1, function ( i_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_20_1, hoisted_1_1[i_2], hoisted_2_1[i_2], UnderlyingMatrix, ConvertRowToMatrix( hoisted_19_1[i_2], hoisted_5_1[i_2], hoisted_6_1[i_2] ) );
           end ) );
 end
@@ -1385,7 +1398,7 @@ function ( cat_1, alpha_1 )
         end );
     hoisted_2_1 := List( deduped_7_1, Source );
     hoisted_1_1 := List( deduped_7_1, Range );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, RightDivide( HomalgIdentityMatrix( hoisted_3_1[o_2], hoisted_4_1 ), hoisted_5_1[o_2] ) );
           end ) );
 end
@@ -1398,7 +1411,7 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    return ForAll( SetOfObjects( cat_1 ), function ( object_2 )
+    return ForAll( SetOfObjects( Source( cat_1 ) ), function ( object_2 )
             return IsZero( DecideZeroColumns( UnderlyingMatrix( arg3_1( object_2 ) ), UnderlyingMatrix( arg2_1( object_2 ) ) ) );
         end );
 end
@@ -1461,7 +1474,7 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    return ForAll( SetOfObjects( cat_1 ), function ( object_2 )
+    return ForAll( SetOfObjects( Source( cat_1 ) ), function ( object_2 )
             return IsZero( DecideZeroRows( UnderlyingMatrix( arg3_1( object_2 ) ), UnderlyingMatrix( arg2_1( object_2 ) ) ) );
         end );
 end
@@ -1514,7 +1527,7 @@ function ( cat_1, alpha_1, P_1 )
     hoisted_1_1 := List( deduped_4_1, function ( logic_new_func_x_2 )
             return SyzygiesOfRows( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, CreateCapCategoryObjectWithAttributes( hoisted_2_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), hoisted_3_1[o_2], UnderlyingMatrix, morphism_attr_1_2 );
@@ -1537,7 +1550,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
         end );
     hoisted_2_1 := List( deduped_5_1, UnderlyingMatrix );
     hoisted_1_1 := List( deduped_5_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := RightDivide( hoisted_2_1[o_2], hoisted_3_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -1552,24 +1565,25 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := ValuesOnAllObjects( arg2_1 );
-    deduped_9_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_8_1 := Range( cat_1 );
-    deduped_7_1 := deduped_9_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
+    deduped_11_1 := ValuesOnAllObjects( arg2_1 );
+    deduped_10_1 := Range( cat_1 );
+    deduped_9_1 := Source( cat_1 );
+    deduped_8_1 := DefiningPairOfUnderlyingQuiver( deduped_9_1 );
+    deduped_7_1 := deduped_8_1[2];
     hoisted_6_1 := List( ValuesOfPreSheaf( Source( arg2_1 ) )[2], UnderlyingMatrix );
-    hoisted_5_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return SyzygiesOfRows( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
     hoisted_4_1 := deduped_7_1;
-    hoisted_3_1 := deduped_8_1;
-    hoisted_2_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := deduped_10_1;
+    hoisted_2_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RowRankOfMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_8_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_9_1, Range, deduped_10_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, hoisted_1_1[o_2] - hoisted_2_1[o_2] );
             end ), LazyHList( [ 1 .. Length( deduped_7_1 ) ], function ( m_2 )
                 local morphism_attr_1_2, deduped_2_2;
@@ -1596,7 +1610,7 @@ function ( cat_1, P_1, alpha_1, mu_1, alphap_1, Pp_1 )
     hoisted_1_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return SyzygiesOfRows( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := RightDivide( hoisted_1_1[o_2] * hoisted_2_1[o_2], hoisted_3_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -1619,7 +1633,7 @@ function ( cat_1, iota_1, tau_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Source );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( tau_1 ), Source( iota_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( tau_1 ), Source( iota_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, RightDivide( hoisted_3_1[o_2], hoisted_4_1[o_2] ) );
           end ) );
 end
@@ -1638,7 +1652,7 @@ function ( cat_1, S_1, source_diagram_1, mat_1, range_diagram_1, T_1 )
     hoisted_3_1 := UnderlyingRing( deduped_5_1 );
     hoisted_2_1 := ValuesOfPreSheaf( T_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( S_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, S_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, S_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_2_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], deduped_1_2, UnderlyingMatrix, UnionOfRows( hoisted_3_1, RankOfObject( deduped_1_2 ), ListN( List( source_diagram_1, function ( Si_3 )
@@ -1695,7 +1709,7 @@ function ( cat_1, morphisms_1, P_1 )
     hoisted_3_1 := deduped_11_1;
     hoisted_2_1 := UnderlyingRing( deduped_10_1 );
     hoisted_1_1 := ValuesOnAllObjects( deduped_9_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2;
               deduped_9_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
@@ -1729,7 +1743,7 @@ function ( cat_1, r_1, a_1 )
     local hoisted_1_1, hoisted_2_1;
     hoisted_2_1 := Range( cat_1 );
     hoisted_1_1 := ValuesOnAllObjects( a_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, Source( deduped_1_2 ), Range( deduped_1_2 ), UnderlyingMatrix, r_1 * UnderlyingMatrix( deduped_1_2 ) );
@@ -1774,7 +1788,7 @@ function ( cat_1, beta_1, alpha_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] * hoisted_4_1[o_2] );
           end ) );
 end
@@ -1795,7 +1809,7 @@ function ( cat_1, alpha_1, beta_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] * hoisted_4_1[o_2] );
           end ) );
 end
@@ -1816,7 +1830,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := [ k_1 + 1 .. Length( objects_1 ) ];
     hoisted_2_1 := [ 1 .. k_1 - 1 ];
     hoisted_1_1 := UnderlyingRing( deduped_7_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2, deduped_3_2;
               deduped_3_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -1844,7 +1858,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := [ 1 .. k_1 - 1 ];
     hoisted_2_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_7_1 ) )[1];
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_7_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_7_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -1874,7 +1888,7 @@ function ( cat_1, morphisms_1, k_1, P_1 )
     hoisted_3_1 := [ 1 .. deduped_11_1 ];
     hoisted_2_1 := deduped_11_1;
     hoisted_1_1 := UnderlyingRing( deduped_10_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( deduped_9_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( deduped_9_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
               deduped_8_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -1904,19 +1918,20 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
-    deduped_11_1 := Length( arg2_1 );
-    deduped_10_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_9_1 := Range( cat_1 );
-    deduped_8_1 := deduped_10_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
+    deduped_12_1 := Length( arg2_1 );
+    deduped_11_1 := Range( cat_1 );
+    deduped_10_1 := Source( cat_1 );
+    deduped_9_1 := DefiningPairOfUnderlyingQuiver( deduped_10_1 );
+    deduped_8_1 := deduped_9_1[2];
     hoisted_7_1 := deduped_8_1;
-    hoisted_6_1 := deduped_9_1;
-    hoisted_5_1 := [ 2 .. deduped_11_1 ];
-    hoisted_4_1 := [ 1 .. deduped_11_1 - 1 ];
-    hoisted_3_1 := [ 1 .. deduped_11_1 ];
-    hoisted_2_1 := deduped_11_1;
-    hoisted_1_1 := UnderlyingRing( deduped_9_1 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_10_1[1] ], function ( o_2 )
+    hoisted_6_1 := deduped_11_1;
+    hoisted_5_1 := [ 2 .. deduped_12_1 ];
+    hoisted_4_1 := [ 1 .. deduped_12_1 - 1 ];
+    hoisted_3_1 := [ 1 .. deduped_12_1 ];
+    hoisted_2_1 := deduped_12_1;
+    hoisted_1_1 := UnderlyingRing( deduped_11_1 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_10_1, Range, deduped_11_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
                 local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
                 deduped_5_2 := List( arg2_1, function ( logic_new_func_x_3 )
                         return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2005,7 +2020,7 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
     hoisted_3_1 := [ 1 .. deduped_16_1 ];
     hoisted_2_1 := deduped_16_1;
     hoisted_1_1 := UnderlyingRing( deduped_15_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2, deduped_11_2, deduped_12_2, deduped_13_2, deduped_14_2, deduped_15_2;
               deduped_15_2 := List( morphismsp_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2065,7 +2080,7 @@ function ( cat_1, a_1, b_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_6_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] + hoisted_4_1[o_2] );
           end ) );
 end
@@ -2078,15 +2093,16 @@ end
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_4_1 ) );
-    hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, RankOfObject, 0 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_6_1 ) );
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, RankOfObject, 0 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := hoisted_3_1;
                 return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, hoisted_1_1, hoisted_1_1, UnderlyingMatrix, morphism_attr_1_2 );
@@ -2108,7 +2124,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := deduped_6_1;
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := UnderlyingRing( deduped_6_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := HomalgIdentityMatrix( Sum( List( objects_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -2135,7 +2151,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := deduped_6_1;
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, UnionOfRows( hoisted_4_1, hoisted_3_1[o_2], List( tau_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
                       end ) ) );
@@ -2165,7 +2181,7 @@ function ( cat_1, alpha_1, tau_1, I_1 )
     hoisted_1_1 := List( deduped_7_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( CAP_JIT_INCOMPLETE_LOGIC( tau_1[1] ) ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( CAP_JIT_INCOMPLETE_LOGIC( tau_1[1] ) ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_5_1[o_2] );
               deduped_1_2 := RightDivide( HomalgIdentityMatrix( (hoisted_1_1[o_2] - hoisted_2_1[o_2]), hoisted_3_1 ) * hoisted_4_1[o_2], UnderlyingMatrix( deduped_2_2 ) );
@@ -2191,7 +2207,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_7_1, RankOfObject );
     hoisted_2_1 := deduped_8_1;
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], hoisted_4_1[o_2], hoisted_5_1 ) );
           end ) );
 end
@@ -2216,7 +2232,7 @@ function ( cat_1, morphisms_1, T_1, tau_1, P_1 )
     hoisted_3_1 := [ 1 .. deduped_11_1 ];
     hoisted_2_1 := deduped_11_1;
     hoisted_1_1 := UnderlyingRing( deduped_10_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
               deduped_7_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2255,7 +2271,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := deduped_6_1;
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( 0, hoisted_3_1[o_2], hoisted_4_1 ) );
           end ) );
 end
@@ -2275,7 +2291,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := UnionOfColumns( hoisted_3_1, hoisted_2_1[o_2], List( tau_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
@@ -2302,7 +2318,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := ValuesOfPreSheaf( P_1 )[1];
     hoisted_1_1 := deduped_6_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, UnionOfColumns( hoisted_4_1, hoisted_3_1[o_2], List( tau_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
                       end ) ) );
@@ -2329,7 +2345,7 @@ function ( cat_1, morphisms_1, T_1, tau_1, P_1 )
     hoisted_3_1 := UnderlyingRing( deduped_10_1 );
     hoisted_2_1 := List( deduped_9_1, RankOfObject );
     hoisted_1_1 := deduped_9_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
               deduped_7_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2370,7 +2386,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_7_1, RankOfObject );
     hoisted_2_1 := deduped_8_1;
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], hoisted_4_1[o_2], hoisted_5_1 ) );
           end ) );
 end
@@ -2391,7 +2407,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := ValuesOfPreSheaf( P_1 )[1];
     hoisted_1_1 := deduped_6_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], 0, hoisted_4_1 ) );
           end ) );
 end
@@ -2414,7 +2430,7 @@ function ( cat_1, a_1, b_1 )
     hoisted_3_1 := List( deduped_7_1, RankOfObject );
     hoisted_2_1 := deduped_8_1;
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, b_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, b_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], hoisted_4_1[o_2], hoisted_5_1 ) );
           end ) );
 end
@@ -2427,15 +2443,16 @@ end
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    hoisted_3_1 := HomalgZeroMatrix( 0, 0, UnderlyingRing( deduped_4_1 ) );
-    hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, RankOfObject, 0 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_3_1 := HomalgZeroMatrix( 0, 0, UnderlyingRing( deduped_6_1 ) );
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, RankOfObject, 0 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := hoisted_3_1;
                 return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, hoisted_1_1, hoisted_1_1, UnderlyingMatrix, morphism_attr_1_2 );

--- a/gap/precompiled_categories/PreSheavesOfFreeAlgebroidInCategoryOfRowsPrecompiled.gi
+++ b/gap/precompiled_categories/PreSheavesOfFreeAlgebroidInCategoryOfRowsPrecompiled.gi
@@ -17,7 +17,7 @@ function ( cat_1, a_1, b_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_6_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] + hoisted_4_1[o_2] );
           end ) );
 end
@@ -38,7 +38,7 @@ function ( cat_1, a_1 )
         end );
     hoisted_2_1 := List( deduped_5_1, Range );
     hoisted_1_1 := List( deduped_5_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] );
           end ) );
 end
@@ -58,7 +58,7 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -80,7 +80,7 @@ function ( cat_1, s_1, a_1, b_1, c_1, r_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -95,24 +95,25 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1;
-    deduped_41_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_40_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_39_1 := SetOfObjects( cat_1 );
-    deduped_38_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_37_1 := Range( cat_1 );
-    deduped_36_1 := deduped_41_1[1];
-    deduped_35_1 := deduped_40_1[1];
-    deduped_34_1 := deduped_41_1[2];
-    deduped_33_1 := deduped_40_1[2];
-    deduped_32_1 := Length( deduped_39_1 );
-    deduped_31_1 := UnderlyingRing( deduped_37_1 );
-    deduped_30_1 := [ 1 .. deduped_32_1 ];
-    deduped_29_1 := [ 1 .. Length( deduped_38_1 ) ];
-    hoisted_2_1 := List( deduped_34_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1;
+    deduped_42_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_41_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_40_1 := Source( cat_1 );
+    deduped_39_1 := Range( cat_1 );
+    deduped_38_1 := deduped_42_1[1];
+    deduped_37_1 := deduped_41_1[1];
+    deduped_36_1 := deduped_42_1[2];
+    deduped_35_1 := deduped_41_1[2];
+    deduped_34_1 := SetOfObjects( deduped_40_1 );
+    deduped_33_1 := SetOfGeneratingMorphisms( deduped_40_1 );
+    deduped_32_1 := UnderlyingRing( deduped_39_1 );
+    deduped_31_1 := Length( deduped_34_1 );
+    deduped_30_1 := [ 1 .. deduped_31_1 ];
+    deduped_29_1 := [ 1 .. Length( deduped_33_1 ) ];
+    hoisted_2_1 := List( deduped_36_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_33_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_35_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
     deduped_28_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
@@ -121,17 +122,17 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_13_1 := deduped_29_1;
     hoisted_12_1 := deduped_28_1;
     hoisted_11_1 := deduped_30_1;
-    hoisted_10_1 := List( deduped_34_1, UnderlyingMatrix );
-    hoisted_9_1 := deduped_31_1;
-    hoisted_8_1 := List( deduped_33_1, function ( logic_new_func_x_2 )
+    hoisted_10_1 := List( deduped_36_1, UnderlyingMatrix );
+    hoisted_9_1 := deduped_32_1;
+    hoisted_8_1 := List( deduped_35_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_38_1, Range );
-    hoisted_6_1 := List( deduped_38_1, Source );
-    hoisted_5_1 := deduped_39_1;
-    hoisted_4_1 := List( deduped_36_1, RankOfObject );
-    hoisted_3_1 := List( deduped_35_1, RankOfObject );
-    deduped_27_1 := SyzygiesOfRows( UnionOfRows( deduped_31_1, Sum( deduped_28_1 ), List( deduped_30_1, function ( logic_new_func_x_2 )
+    hoisted_7_1 := List( deduped_33_1, Range );
+    hoisted_6_1 := List( deduped_33_1, Source );
+    hoisted_5_1 := deduped_34_1;
+    hoisted_4_1 := List( deduped_38_1, RankOfObject );
+    hoisted_3_1 := List( deduped_37_1, RankOfObject );
+    deduped_27_1 := SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_28_1 ), List( deduped_30_1, function ( logic_new_func_x_2 )
                 local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                 deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                 deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -161,16 +162,16 @@ function ( cat_1, arg2_1, arg3_1 )
     deduped_26_1 := NumberRows( deduped_27_1 );
     deduped_25_1 := 1 * deduped_26_1;
     deduped_24_1 := [ 1 .. deduped_25_1 ];
-    hoisted_23_1 := deduped_37_1;
+    hoisted_23_1 := deduped_39_1;
     hoisted_21_1 := deduped_24_1;
     hoisted_20_1 := deduped_27_1;
-    hoisted_19_1 := deduped_32_1;
+    hoisted_19_1 := deduped_31_1;
     hoisted_18_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
             return hoisted_3_1[logic_new_func_x_2] * hoisted_4_1[logic_new_func_x_2];
         end );
     hoisted_17_1 := deduped_26_1;
-    hoisted_16_1 := HomalgIdentityMatrix( deduped_25_1, deduped_31_1 );
-    hoisted_22_1 := List( [ 1 .. Length( deduped_35_1 ) ], function ( logic_new_func_x_2 )
+    hoisted_16_1 := HomalgIdentityMatrix( deduped_25_1, deduped_32_1 );
+    hoisted_22_1 := List( [ 1 .. Length( deduped_37_1 ) ], function ( logic_new_func_x_2 )
             local hoisted_1_2, deduped_2_2;
             deduped_2_2 := hoisted_18_1[logic_new_func_x_2];
             hoisted_1_2 := hoisted_20_1 * UnionOfRows( HomalgZeroMatrix( Sum( hoisted_18_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), deduped_2_2, hoisted_9_1 ), HomalgIdentityMatrix( deduped_2_2, hoisted_9_1 ), HomalgZeroMatrix( Sum( hoisted_18_1{[ (logic_new_func_x_2 + 1) .. hoisted_19_1 ]} ), deduped_2_2, hoisted_9_1 ) );
@@ -178,8 +179,8 @@ function ( cat_1, arg2_1, arg3_1 )
                     return ConvertRowToMatrix( CertainRows( hoisted_16_1, [ logic_new_func_x_3 ] ), 1, hoisted_17_1 ) * hoisted_1_2;
                 end );
         end );
-    hoisted_15_1 := deduped_36_1;
-    hoisted_14_1 := deduped_35_1;
+    hoisted_15_1 := deduped_38_1;
+    hoisted_14_1 := deduped_37_1;
     return List( deduped_24_1, function ( j_2 )
             return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, LazyHList( hoisted_11_1, function ( i_3 )
                       return CreateCapCategoryMorphismWithAttributes( hoisted_23_1, hoisted_14_1[i_3], hoisted_15_1[i_3], UnderlyingMatrix, ConvertRowToMatrix( hoisted_22_1[i_3][j_2], hoisted_3_1[i_3], hoisted_4_1[i_3] ) );
@@ -205,7 +206,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
     hoisted_3_1 := List( deduped_8_1, RankOfObject );
     hoisted_2_1 := ValuesOfPreSheaf( r_1 )[1];
     hoisted_1_1 := deduped_8_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
               deduped_3_2 := hoisted_3_1[o_2];
               hoisted_2_2 := hoisted_5_1[o_2];
@@ -236,7 +237,7 @@ function ( cat_1, s_1, a_1, b_1, r_1 )
     hoisted_3_1 := List( deduped_8_1, RankOfObject );
     hoisted_2_1 := ValuesOfPreSheaf( r_1 )[1];
     hoisted_1_1 := deduped_8_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
               deduped_3_2 := hoisted_3_1[o_2];
               hoisted_2_2 := hoisted_5_1[o_2];
@@ -273,7 +274,7 @@ function ( cat_1, alpha_1, I_1 )
         end );
     hoisted_2_1 := List( deduped_8_1, UnderlyingMatrix );
     hoisted_1_1 := List( deduped_8_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), I_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), I_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := RightDivide( hoisted_2_1[o_2], HomalgIdentityMatrix( (hoisted_3_1[o_2] - hoisted_4_1[o_2]), hoisted_5_1 ) * hoisted_6_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_7_1, hoisted_1_1[o_2], CreateCapCategoryObjectWithAttributes( hoisted_7_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -288,41 +289,42 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1;
-    deduped_23_1 := SetOfObjects( cat_1 );
-    deduped_22_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_21_1 := ValuesOfPreSheaf( Range( arg2_1 ) );
-    deduped_20_1 := ValuesOfPreSheaf( Source( arg2_1 ) );
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1;
+    deduped_24_1 := Source( cat_1 );
+    deduped_23_1 := ValuesOfPreSheaf( Range( arg2_1 ) );
+    deduped_22_1 := ValuesOfPreSheaf( Source( arg2_1 ) );
+    deduped_21_1 := SetOfObjects( deduped_24_1 );
+    deduped_20_1 := SetOfGeneratingMorphisms( deduped_24_1 );
     deduped_19_1 := UnderlyingRing( Range( cat_1 ) );
-    deduped_18_1 := [ 1 .. Length( deduped_23_1 ) ];
-    deduped_17_1 := [ 1 .. Length( deduped_22_1 ) ];
-    deduped_16_1 := deduped_21_1[2];
-    deduped_15_1 := deduped_20_1[2];
-    hoisted_2_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
+    deduped_18_1 := deduped_23_1[2];
+    deduped_17_1 := deduped_22_1[2];
+    deduped_16_1 := [ 1 .. Length( deduped_21_1 ) ];
+    deduped_15_1 := [ 1 .. Length( deduped_20_1 ) ];
+    hoisted_2_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_15_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_14_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
+    deduped_14_1 := List( deduped_15_1, function ( logic_new_func_x_2 )
             return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
         end );
-    hoisted_13_1 := deduped_17_1;
+    hoisted_13_1 := deduped_15_1;
     hoisted_12_1 := deduped_14_1;
-    hoisted_11_1 := deduped_18_1;
-    hoisted_10_1 := List( deduped_16_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_16_1;
+    hoisted_10_1 := List( deduped_18_1, UnderlyingMatrix );
     hoisted_9_1 := deduped_19_1;
-    hoisted_8_1 := List( deduped_15_1, function ( logic_new_func_x_2 )
+    hoisted_8_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_22_1, Range );
-    hoisted_6_1 := List( deduped_22_1, Source );
-    hoisted_5_1 := deduped_23_1;
-    hoisted_4_1 := List( deduped_21_1[1], RankOfObject );
-    hoisted_3_1 := List( deduped_20_1[1], RankOfObject );
+    hoisted_7_1 := List( deduped_20_1, Range );
+    hoisted_6_1 := List( deduped_20_1, Source );
+    hoisted_5_1 := deduped_21_1;
+    hoisted_4_1 := List( deduped_23_1[1], RankOfObject );
+    hoisted_3_1 := List( deduped_22_1[1], RankOfObject );
     return EntriesOfHomalgMatrix( RightDivide( UnionOfColumns( deduped_19_1, 1, List( ListOfValues( ValuesOnAllObjects( arg2_1 ) ), function ( logic_new_func_x_2 )
                   return ConvertMatrixToRow( UnderlyingMatrix( logic_new_func_x_2 ) );
-              end ) ), SyzygiesOfRows( UnionOfRows( deduped_19_1, Sum( deduped_14_1 ), List( deduped_18_1, function ( logic_new_func_x_2 )
+              end ) ), SyzygiesOfRows( UnionOfRows( deduped_19_1, Sum( deduped_14_1 ), List( deduped_16_1, function ( logic_new_func_x_2 )
                     local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                     deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                     deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -367,7 +369,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
     hoisted_1_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := LeftDivide( hoisted_1_1[o_2], hoisted_2_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_3_1, CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), hoisted_4_1[o_2], UnderlyingMatrix, morphism_attr_1_2 );
@@ -382,24 +384,25 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := ValuesOnAllObjects( arg2_1 );
-    deduped_9_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_8_1 := Range( cat_1 );
-    deduped_7_1 := deduped_9_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
+    deduped_11_1 := ValuesOnAllObjects( arg2_1 );
+    deduped_10_1 := Range( cat_1 );
+    deduped_9_1 := Source( cat_1 );
+    deduped_8_1 := DefiningPairOfUnderlyingQuiver( deduped_9_1 );
+    deduped_7_1 := deduped_8_1[2];
     hoisted_6_1 := List( ValuesOfPreSheaf( Range( arg2_1 ) )[2], UnderlyingMatrix );
-    hoisted_5_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
     hoisted_4_1 := deduped_7_1;
-    hoisted_3_1 := deduped_8_1;
-    hoisted_2_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := deduped_10_1;
+    hoisted_2_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RowRankOfMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_8_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_9_1, Range, deduped_10_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, hoisted_1_1[o_2] - hoisted_2_1[o_2] );
             end ), LazyHList( [ 1 .. Length( deduped_7_1 ) ], function ( m_2 )
                 local morphism_attr_1_2, deduped_2_2;
@@ -426,7 +429,7 @@ function ( cat_1, P_1, alpha_1, mu_1, alphap_1, Pp_1 )
     hoisted_1_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := LeftDivide( hoisted_1_1[o_2], hoisted_2_1[o_2] * hoisted_3_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -448,7 +451,7 @@ function ( cat_1, alpha_1, P_1 )
             return SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
     hoisted_1_1 := List( deduped_4_1, Range );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := hoisted_2_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_3_1, hoisted_1_1[o_2], CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -471,7 +474,7 @@ function ( cat_1, epsilon_1, tau_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := List( deduped_6_1, Range );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( epsilon_1 ), Range( tau_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( epsilon_1 ), Range( tau_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, LeftDivide( hoisted_3_1[o_2], hoisted_4_1[o_2] ) );
           end ) );
 end
@@ -492,7 +495,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
     hoisted_3_1 := List( deduped_7_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_6_1 ) )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( S_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -518,7 +521,7 @@ function ( cat_1, alpha_1, S_1, i_1 )
     hoisted_3_1 := List( deduped_7_1, UnderlyingMatrix );
     hoisted_2_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_6_1 ) )[1];
     hoisted_1_1 := List( deduped_7_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( S_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -536,17 +539,18 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
-    deduped_9_1 := Length( arg2_1 );
-    deduped_8_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_7_1 := Range( cat_1 );
-    deduped_6_1 := deduped_8_1[2];
-    hoisted_5_1 := [ 1 .. deduped_9_1 ];
-    hoisted_4_1 := deduped_9_1;
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := Length( arg2_1 );
+    deduped_9_1 := Range( cat_1 );
+    deduped_8_1 := Source( cat_1 );
+    deduped_7_1 := DefiningPairOfUnderlyingQuiver( deduped_8_1 );
+    deduped_6_1 := deduped_7_1[2];
+    hoisted_5_1 := [ 1 .. deduped_10_1 ];
+    hoisted_4_1 := deduped_10_1;
     hoisted_3_1 := deduped_6_1;
-    hoisted_2_1 := UnderlyingRing( deduped_7_1 );
-    hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_7_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
+    hoisted_2_1 := UnderlyingRing( deduped_9_1 );
+    hoisted_1_1 := deduped_9_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_8_1, Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_7_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_1_1, RankOfObject, Sum( List( arg2_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
                         end ) ) );
@@ -591,7 +595,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
     hoisted_3_1 := Length( objectsp_1 );
     hoisted_2_1 := List( deduped_7_1, RankOfObject );
     hoisted_1_1 := UnderlyingRing( deduped_8_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
               deduped_5_2 := List( objectsp_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -620,17 +624,18 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
-    deduped_9_1 := Length( arg2_1 );
-    deduped_8_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_7_1 := Range( cat_1 );
-    deduped_6_1 := deduped_8_1[2];
-    hoisted_5_1 := [ 1 .. deduped_9_1 ];
-    hoisted_4_1 := deduped_9_1;
-    hoisted_3_1 := UnderlyingRing( deduped_7_1 );
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := Length( arg2_1 );
+    deduped_9_1 := Range( cat_1 );
+    deduped_8_1 := Source( cat_1 );
+    deduped_7_1 := DefiningPairOfUnderlyingQuiver( deduped_8_1 );
+    deduped_6_1 := deduped_7_1[2];
+    hoisted_5_1 := [ 1 .. deduped_10_1 ];
+    hoisted_4_1 := deduped_10_1;
+    hoisted_3_1 := UnderlyingRing( deduped_9_1 );
     hoisted_2_1 := deduped_6_1;
-    hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_7_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
+    hoisted_1_1 := deduped_9_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_8_1, Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_7_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_1_1, RankOfObject, Sum( List( arg2_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
                         end ) ) );
@@ -675,7 +680,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
     hoisted_3_1 := UnderlyingRing( deduped_8_1 );
     hoisted_2_1 := List( deduped_7_1, RankOfObject );
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
               deduped_5_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -704,16 +709,17 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1;
-    deduped_4_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_3_1 := Range( cat_1 );
-    hoisted_2_1 := UnderlyingRing( deduped_3_1 );
-    hoisted_1_1 := deduped_3_1;
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_3_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
+    deduped_5_1 := Range( cat_1 );
+    deduped_4_1 := Source( cat_1 );
+    deduped_3_1 := DefiningPairOfUnderlyingQuiver( deduped_4_1 );
+    hoisted_2_1 := UnderlyingRing( deduped_5_1 );
+    hoisted_1_1 := deduped_5_1;
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_4_1, Range, deduped_5_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_3_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_1_1, RankOfObject, Sum( List( arg2_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
                         end ) ) );
-            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_3_1[2] ) ], function ( m_2 )
                 local deduped_1_2;
                 deduped_1_2 := DiagMat( hoisted_2_1, List( arg2_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[2][m_2] ) );
@@ -736,7 +742,7 @@ function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
     hoisted_3_1 := UnderlyingRing( deduped_5_1 );
     hoisted_2_1 := ValuesOfPreSheaf( Pp_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, DiagMat( hoisted_3_1, List( L_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
                       end ) ) );
@@ -762,19 +768,20 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
-    deduped_11_1 := Length( arg2_1 );
-    deduped_10_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_9_1 := Range( cat_1 );
-    deduped_8_1 := deduped_10_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
+    deduped_12_1 := Length( arg2_1 );
+    deduped_11_1 := Range( cat_1 );
+    deduped_10_1 := Source( cat_1 );
+    deduped_9_1 := DefiningPairOfUnderlyingQuiver( deduped_10_1 );
+    deduped_8_1 := deduped_9_1[2];
     hoisted_7_1 := deduped_8_1;
-    hoisted_6_1 := deduped_9_1;
-    hoisted_5_1 := [ 2 .. deduped_11_1 ];
-    hoisted_4_1 := [ 1 .. deduped_11_1 - 1 ];
-    hoisted_3_1 := [ 1 .. deduped_11_1 ];
-    hoisted_2_1 := deduped_11_1;
-    hoisted_1_1 := UnderlyingRing( deduped_9_1 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_10_1[1] ], function ( o_2 )
+    hoisted_6_1 := deduped_11_1;
+    hoisted_5_1 := [ 2 .. deduped_12_1 ];
+    hoisted_4_1 := [ 1 .. deduped_12_1 - 1 ];
+    hoisted_3_1 := [ 1 .. deduped_12_1 ];
+    hoisted_2_1 := deduped_12_1;
+    hoisted_1_1 := UnderlyingRing( deduped_11_1 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_10_1, Range, deduped_11_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
                 local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
                 deduped_5_2 := List( arg2_1, function ( logic_new_func_x_3 )
                         return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -863,7 +870,7 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
     hoisted_3_1 := UnderlyingRing( deduped_15_1 );
     hoisted_2_1 := List( deduped_14_1, RankOfObject );
     hoisted_1_1 := deduped_14_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2, deduped_11_2, deduped_12_2, deduped_13_2, deduped_14_2, deduped_15_2;
               deduped_15_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -914,64 +921,65 @@ end
         
 ########
 function ( cat_1, source_1, alpha_1, beta_1, range_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1;
-    deduped_39_1 := SetOfObjects( cat_1 );
-    deduped_38_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_37_1 := Range( cat_1 );
-    deduped_36_1 := ValuesOfPreSheaf( Range( beta_1 ) );
-    deduped_35_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
-    deduped_34_1 := ValuesOfPreSheaf( Source( beta_1 ) );
-    deduped_33_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
-    deduped_32_1 := UnderlyingRing( deduped_37_1 );
-    deduped_31_1 := [ 1 .. Length( deduped_39_1 ) ];
-    deduped_30_1 := [ 1 .. Length( deduped_38_1 ) ];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1;
+    deduped_40_1 := Source( cat_1 );
+    deduped_39_1 := Range( cat_1 );
+    deduped_38_1 := ValuesOfPreSheaf( Range( beta_1 ) );
+    deduped_37_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
+    deduped_36_1 := ValuesOfPreSheaf( Source( beta_1 ) );
+    deduped_35_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
+    deduped_34_1 := SetOfObjects( deduped_40_1 );
+    deduped_33_1 := SetOfGeneratingMorphisms( deduped_40_1 );
+    deduped_32_1 := UnderlyingRing( deduped_39_1 );
+    deduped_31_1 := deduped_38_1[2];
+    deduped_30_1 := deduped_37_1[2];
     deduped_29_1 := deduped_36_1[2];
     deduped_28_1 := deduped_35_1[2];
-    deduped_27_1 := deduped_34_1[2];
-    deduped_26_1 := deduped_33_1[2];
-    hoisted_17_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
+    deduped_27_1 := [ 1 .. Length( deduped_34_1 ) ];
+    deduped_26_1 := [ 1 .. Length( deduped_33_1 ) ];
+    hoisted_17_1 := List( deduped_31_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_16_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
+    hoisted_16_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_25_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
+    deduped_25_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
             return hoisted_16_1[logic_new_func_x_2] * hoisted_17_1[logic_new_func_x_2];
         end );
-    hoisted_2_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_2_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_24_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
+    deduped_24_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
             return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
         end );
     hoisted_22_1 := deduped_25_1;
-    hoisted_21_1 := List( deduped_29_1, UnderlyingMatrix );
-    hoisted_20_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
+    hoisted_21_1 := List( deduped_31_1, UnderlyingMatrix );
+    hoisted_20_1 := List( deduped_30_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_19_1 := List( deduped_36_1[1], RankOfObject );
-    hoisted_18_1 := List( deduped_35_1[1], RankOfObject );
+    hoisted_19_1 := List( deduped_38_1[1], RankOfObject );
+    hoisted_18_1 := List( deduped_37_1[1], RankOfObject );
     hoisted_15_1 := List( ValuesOnAllObjects( beta_1 ), UnderlyingMatrix );
     hoisted_14_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_13_1 := deduped_30_1;
+    hoisted_13_1 := deduped_26_1;
     hoisted_12_1 := deduped_24_1;
-    hoisted_11_1 := deduped_31_1;
-    hoisted_10_1 := List( deduped_27_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_27_1;
+    hoisted_10_1 := List( deduped_29_1, UnderlyingMatrix );
     hoisted_9_1 := deduped_32_1;
-    hoisted_8_1 := List( deduped_26_1, function ( logic_new_func_x_2 )
+    hoisted_8_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_38_1, Range );
-    hoisted_6_1 := List( deduped_38_1, Source );
-    hoisted_5_1 := deduped_39_1;
-    hoisted_4_1 := List( deduped_34_1[1], RankOfObject );
-    hoisted_3_1 := List( deduped_33_1[1], RankOfObject );
-    deduped_23_1 := RightDivide( SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_24_1 ), List( deduped_31_1, function ( logic_new_func_x_2 )
+    hoisted_7_1 := List( deduped_33_1, Range );
+    hoisted_6_1 := List( deduped_33_1, Source );
+    hoisted_5_1 := deduped_34_1;
+    hoisted_4_1 := List( deduped_36_1[1], RankOfObject );
+    hoisted_3_1 := List( deduped_35_1[1], RankOfObject );
+    deduped_23_1 := RightDivide( SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_24_1 ), List( deduped_27_1, function ( logic_new_func_x_2 )
                     local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                     deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                     deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -997,9 +1005,9 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                               fi;
                               return;
                           end ) );
-                end ) ) ) * DiagMat( deduped_32_1, List( deduped_31_1, function ( logic_new_func_x_2 )
+                end ) ) ) * DiagMat( deduped_32_1, List( deduped_27_1, function ( logic_new_func_x_2 )
                   return KroneckerMat( hoisted_14_1[logic_new_func_x_2], hoisted_15_1[logic_new_func_x_2] );
-              end ) ), SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_25_1 ), List( deduped_31_1, function ( logic_new_func_x_2 )
+              end ) ), SyzygiesOfRows( UnionOfRows( deduped_32_1, Sum( deduped_25_1 ), List( deduped_27_1, function ( logic_new_func_x_2 )
                   local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                   deduped_7_2 := hoisted_19_1[logic_new_func_x_2];
                   deduped_6_2 := hoisted_18_1[logic_new_func_x_2];
@@ -1026,7 +1034,7 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                             return;
                         end ) );
               end ) ) ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_37_1, CreateCapCategoryObjectWithAttributes( deduped_37_1, RankOfObject, NumberRows( deduped_23_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_37_1, RankOfObject, NumberColumns( deduped_23_1 ) ), UnderlyingMatrix, deduped_23_1 );
+    return CreateCapCategoryMorphismWithAttributes( deduped_39_1, CreateCapCategoryObjectWithAttributes( deduped_39_1, RankOfObject, NumberRows( deduped_23_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_39_1, RankOfObject, NumberColumns( deduped_23_1 ) ), UnderlyingMatrix, deduped_23_1 );
 end
 ########
         
@@ -1037,21 +1045,22 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1;
-    deduped_24_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_23_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_22_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_21_1 := SetOfObjects( cat_1 );
-    deduped_20_1 := Range( cat_1 );
-    deduped_19_1 := deduped_24_1[2];
-    deduped_18_1 := deduped_23_1[2];
-    deduped_17_1 := UnderlyingRing( deduped_20_1 );
-    deduped_16_1 := [ 1 .. Length( deduped_22_1 ) ];
-    deduped_15_1 := [ 1 .. Length( deduped_21_1 ) ];
-    hoisted_4_1 := List( deduped_19_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1;
+    deduped_25_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_24_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_23_1 := Source( cat_1 );
+    deduped_22_1 := Range( cat_1 );
+    deduped_21_1 := deduped_25_1[2];
+    deduped_20_1 := deduped_24_1[2];
+    deduped_19_1 := SetOfGeneratingMorphisms( deduped_23_1 );
+    deduped_18_1 := UnderlyingRing( deduped_22_1 );
+    deduped_17_1 := SetOfObjects( deduped_23_1 );
+    deduped_16_1 := [ 1 .. Length( deduped_19_1 ) ];
+    deduped_15_1 := [ 1 .. Length( deduped_17_1 ) ];
+    hoisted_4_1 := List( deduped_21_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_3_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := List( deduped_20_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
     deduped_14_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
@@ -1060,19 +1069,19 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_13_1 := deduped_16_1;
     hoisted_12_1 := deduped_14_1;
     hoisted_11_1 := deduped_15_1;
-    hoisted_10_1 := List( deduped_19_1, UnderlyingMatrix );
-    hoisted_9_1 := deduped_17_1;
-    hoisted_8_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
+    hoisted_10_1 := List( deduped_21_1, UnderlyingMatrix );
+    hoisted_9_1 := deduped_18_1;
+    hoisted_8_1 := List( deduped_20_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_22_1, Range );
-    hoisted_6_1 := List( deduped_22_1, Source );
-    hoisted_5_1 := deduped_21_1;
-    hoisted_2_1 := List( deduped_24_1[1], RankOfObject );
-    hoisted_1_1 := List( deduped_23_1[1], RankOfObject );
-    return CreateCapCategoryObjectWithAttributes( deduped_20_1, RankOfObject, Sum( List( deduped_15_1, function ( logic_new_func_x_2 )
+    hoisted_7_1 := List( deduped_19_1, Range );
+    hoisted_6_1 := List( deduped_19_1, Source );
+    hoisted_5_1 := deduped_17_1;
+    hoisted_2_1 := List( deduped_25_1[1], RankOfObject );
+    hoisted_1_1 := List( deduped_24_1[1], RankOfObject );
+    return CreateCapCategoryObjectWithAttributes( deduped_22_1, RankOfObject, Sum( List( deduped_15_1, function ( logic_new_func_x_2 )
                   return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
-              end ) ) - RowRankOfMatrix( UnionOfRows( deduped_17_1, Sum( deduped_14_1 ), List( deduped_15_1, function ( logic_new_func_x_2 )
+              end ) ) - RowRankOfMatrix( UnionOfRows( deduped_18_1, Sum( deduped_14_1 ), List( deduped_15_1, function ( logic_new_func_x_2 )
                     local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                     deduped_7_2 := hoisted_2_1[logic_new_func_x_2];
                     deduped_6_2 := hoisted_1_1[logic_new_func_x_2];
@@ -1116,7 +1125,7 @@ function ( cat_1, a_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -1146,7 +1155,7 @@ function ( cat_1, alpha_1, I_1 )
     hoisted_1_1 := List( deduped_7_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := HomalgIdentityMatrix( (hoisted_1_1[o_2] - hoisted_2_1[o_2]), hoisted_3_1 ) * hoisted_4_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CreateCapCategoryObjectWithAttributes( hoisted_5_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), hoisted_6_1[o_2], UnderlyingMatrix, morphism_attr_1_2 );
@@ -1161,25 +1170,26 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
-    deduped_11_1 := ValuesOnAllObjects( arg2_1 );
-    deduped_10_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_9_1 := Range( cat_1 );
-    deduped_8_1 := deduped_10_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
+    deduped_12_1 := ValuesOnAllObjects( arg2_1 );
+    deduped_11_1 := Range( cat_1 );
+    deduped_10_1 := Source( cat_1 );
+    deduped_9_1 := DefiningPairOfUnderlyingQuiver( deduped_10_1 );
+    deduped_8_1 := deduped_9_1[2];
     hoisted_7_1 := List( ValuesOfPreSheaf( Range( arg2_1 ) )[2], UnderlyingMatrix );
-    hoisted_6_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
+    hoisted_6_1 := List( deduped_12_1, function ( logic_new_func_x_2 )
             return SyzygiesOfRows( SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) ) );
         end );
-    hoisted_5_1 := UnderlyingRing( deduped_9_1 );
+    hoisted_5_1 := UnderlyingRing( deduped_11_1 );
     hoisted_4_1 := deduped_8_1;
-    hoisted_3_1 := deduped_9_1;
-    hoisted_2_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := deduped_11_1;
+    hoisted_2_1 := List( deduped_12_1, function ( logic_new_func_x_2 )
             return RowRankOfMatrix( SyzygiesOfColumns( UnderlyingMatrix( logic_new_func_x_2 ) ) );
         end );
-    hoisted_1_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_12_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_10_1[1] ], function ( o_2 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_10_1, Range, deduped_11_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, hoisted_1_1[o_2] - hoisted_2_1[o_2] );
             end ), LazyHList( [ 1 .. Length( deduped_8_1 ) ], function ( m_2 )
                 local morphism_attr_1_2, deduped_2_2, deduped_3_2, deduped_4_2;
@@ -1199,15 +1209,16 @@ end
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_4_1 ) );
-    hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, RankOfObject, 0 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_6_1 ) );
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, RankOfObject, 0 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := hoisted_3_1;
                 return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, hoisted_1_1, hoisted_1_1, UnderlyingMatrix, morphism_attr_1_2 );
@@ -1230,7 +1241,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := UnderlyingRing( deduped_7_1 );
     hoisted_2_1 := [ 1 .. k_1 - 1 ];
     hoisted_1_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_6_1 ) )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_6_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2, deduped_3_2;
               deduped_3_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -1258,7 +1269,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := [ 1 .. k_1 - 1 ];
     hoisted_2_1 := ValuesOfPreSheaf( P_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_7_1 ) )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_7_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_7_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -1288,7 +1299,7 @@ function ( cat_1, morphisms_1, k_1, P_1 )
     hoisted_3_1 := deduped_11_1;
     hoisted_2_1 := UnderlyingRing( deduped_10_1 );
     hoisted_1_1 := ValuesOnAllObjects( deduped_9_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
               deduped_8_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -1318,42 +1329,43 @@ end
         
 ########
 function ( cat_1, alpha_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1;
-    deduped_25_1 := SetOfObjects( cat_1 );
-    deduped_24_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_23_1 := Range( cat_1 );
-    deduped_22_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
-    deduped_21_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
-    deduped_20_1 := UnderlyingRing( deduped_23_1 );
-    deduped_19_1 := [ 1 .. Length( deduped_25_1 ) ];
-    deduped_18_1 := [ 1 .. Length( deduped_24_1 ) ];
-    deduped_17_1 := deduped_22_1[2];
-    deduped_16_1 := deduped_21_1[2];
-    hoisted_2_1 := List( deduped_17_1, function ( logic_new_func_x_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1;
+    deduped_26_1 := Source( cat_1 );
+    deduped_25_1 := Range( cat_1 );
+    deduped_24_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
+    deduped_23_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
+    deduped_22_1 := SetOfObjects( deduped_26_1 );
+    deduped_21_1 := SetOfGeneratingMorphisms( deduped_26_1 );
+    deduped_20_1 := UnderlyingRing( deduped_25_1 );
+    deduped_19_1 := deduped_24_1[2];
+    deduped_18_1 := deduped_23_1[2];
+    deduped_17_1 := [ 1 .. Length( deduped_22_1 ) ];
+    deduped_16_1 := [ 1 .. Length( deduped_21_1 ) ];
+    hoisted_2_1 := List( deduped_19_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    deduped_15_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
+    deduped_15_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
             return hoisted_1_1[logic_new_func_x_2] * hoisted_2_1[logic_new_func_x_2];
         end );
-    hoisted_13_1 := deduped_18_1;
+    hoisted_13_1 := deduped_16_1;
     hoisted_12_1 := deduped_15_1;
-    hoisted_11_1 := deduped_19_1;
-    hoisted_10_1 := List( deduped_17_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_17_1;
+    hoisted_10_1 := List( deduped_19_1, UnderlyingMatrix );
     hoisted_9_1 := deduped_20_1;
-    hoisted_8_1 := List( deduped_16_1, function ( logic_new_func_x_2 )
+    hoisted_8_1 := List( deduped_18_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_7_1 := List( deduped_24_1, Range );
-    hoisted_6_1 := List( deduped_24_1, Source );
-    hoisted_5_1 := deduped_25_1;
-    hoisted_4_1 := List( deduped_22_1[1], RankOfObject );
-    hoisted_3_1 := List( deduped_21_1[1], RankOfObject );
+    hoisted_7_1 := List( deduped_21_1, Range );
+    hoisted_6_1 := List( deduped_21_1, Source );
+    hoisted_5_1 := deduped_22_1;
+    hoisted_4_1 := List( deduped_24_1[1], RankOfObject );
+    hoisted_3_1 := List( deduped_23_1[1], RankOfObject );
     deduped_14_1 := RightDivide( UnionOfColumns( deduped_20_1, 1, List( ListOfValues( ValuesOnAllObjects( alpha_1 ) ), function ( logic_new_func_x_2 )
                 return ConvertMatrixToRow( UnderlyingMatrix( logic_new_func_x_2 ) );
-            end ) ), SyzygiesOfRows( UnionOfRows( deduped_20_1, Sum( deduped_15_1 ), List( deduped_19_1, function ( logic_new_func_x_2 )
+            end ) ), SyzygiesOfRows( UnionOfRows( deduped_20_1, Sum( deduped_15_1 ), List( deduped_17_1, function ( logic_new_func_x_2 )
                   local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                   deduped_7_2 := hoisted_4_1[logic_new_func_x_2];
                   deduped_6_2 := hoisted_3_1[logic_new_func_x_2];
@@ -1380,7 +1392,7 @@ function ( cat_1, alpha_1 )
                             return;
                         end ) );
               end ) ) ) );
-    return CreateCapCategoryMorphismWithAttributes( deduped_23_1, CreateCapCategoryObjectWithAttributes( deduped_23_1, RankOfObject, 1 ), CreateCapCategoryObjectWithAttributes( deduped_23_1, RankOfObject, NumberColumns( deduped_14_1 ) ), UnderlyingMatrix, deduped_14_1 );
+    return CreateCapCategoryMorphismWithAttributes( deduped_25_1, CreateCapCategoryObjectWithAttributes( deduped_25_1, RankOfObject, 1 ), CreateCapCategoryObjectWithAttributes( deduped_25_1, RankOfObject, NumberColumns( deduped_14_1 ) ), UnderlyingMatrix, deduped_14_1 );
 end
 ########
         
@@ -1390,45 +1402,46 @@ end
     AddInterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,
         
 ########
-function ( cat_1, arg2_1, arg3_1, arg4_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1;
-    deduped_34_1 := Range( cat_1 );
-    deduped_33_1 := SetOfGeneratingMorphisms( cat_1 );
-    deduped_32_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_31_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_30_1 := SetOfObjects( cat_1 );
-    deduped_29_1 := UnderlyingRing( deduped_34_1 );
-    deduped_28_1 := deduped_32_1[2];
-    deduped_27_1 := deduped_31_1[2];
-    deduped_26_1 := deduped_32_1[1];
-    deduped_25_1 := deduped_31_1[1];
-    deduped_24_1 := Length( deduped_30_1 );
-    deduped_23_1 := [ 1 .. Length( deduped_33_1 ) ];
+function ( cat_1, source_1, range_1, alpha_1 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1;
+    deduped_35_1 := Range( cat_1 );
+    deduped_34_1 := ValuesOfPreSheaf( range_1 );
+    deduped_33_1 := ValuesOfPreSheaf( source_1 );
+    deduped_32_1 := Source( cat_1 );
+    deduped_31_1 := UnderlyingRing( deduped_35_1 );
+    deduped_30_1 := SetOfGeneratingMorphisms( deduped_32_1 );
+    deduped_29_1 := deduped_34_1[2];
+    deduped_28_1 := deduped_33_1[2];
+    deduped_27_1 := deduped_34_1[1];
+    deduped_26_1 := deduped_33_1[1];
+    deduped_25_1 := SetOfObjects( deduped_32_1 );
+    deduped_24_1 := Length( deduped_25_1 );
+    deduped_23_1 := [ 1 .. Length( deduped_30_1 ) ];
     deduped_22_1 := [ 1 .. deduped_24_1 ];
-    hoisted_4_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
+    hoisted_4_1 := List( deduped_29_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    hoisted_3_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
     deduped_21_1 := List( deduped_23_1, function ( logic_new_func_x_2 )
             return hoisted_3_1[logic_new_func_x_2] * hoisted_4_1[logic_new_func_x_2];
         end );
-    hoisted_20_1 := deduped_34_1;
+    hoisted_20_1 := deduped_35_1;
     hoisted_15_1 := deduped_23_1;
     hoisted_14_1 := deduped_21_1;
     hoisted_13_1 := deduped_22_1;
-    hoisted_12_1 := List( deduped_28_1, UnderlyingMatrix );
-    hoisted_11_1 := deduped_29_1;
-    hoisted_10_1 := List( deduped_27_1, function ( logic_new_func_x_2 )
+    hoisted_12_1 := List( deduped_29_1, UnderlyingMatrix );
+    hoisted_11_1 := deduped_31_1;
+    hoisted_10_1 := List( deduped_28_1, function ( logic_new_func_x_2 )
             return TransposedMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_9_1 := List( deduped_33_1, Range );
-    hoisted_8_1 := List( deduped_33_1, Source );
-    hoisted_7_1 := deduped_30_1;
-    hoisted_6_1 := List( deduped_26_1, RankOfObject );
-    hoisted_5_1 := List( deduped_25_1, RankOfObject );
-    hoisted_18_1 := UnderlyingMatrix( arg4_1 ) * SyzygiesOfRows( UnionOfRows( deduped_29_1, Sum( deduped_21_1 ), List( deduped_22_1, function ( logic_new_func_x_2 )
+    hoisted_9_1 := List( deduped_30_1, Range );
+    hoisted_8_1 := List( deduped_30_1, Source );
+    hoisted_7_1 := deduped_25_1;
+    hoisted_6_1 := List( deduped_27_1, RankOfObject );
+    hoisted_5_1 := List( deduped_26_1, RankOfObject );
+    hoisted_18_1 := UnderlyingMatrix( alpha_1 ) * SyzygiesOfRows( UnionOfRows( deduped_31_1, Sum( deduped_21_1 ), List( deduped_22_1, function ( logic_new_func_x_2 )
                   local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
                   deduped_7_2 := hoisted_6_1[logic_new_func_x_2];
                   deduped_6_2 := hoisted_5_1[logic_new_func_x_2];
@@ -1465,9 +1478,9 @@ function ( cat_1, arg2_1, arg3_1, arg4_1 )
             deduped_1_2 := hoisted_5_1[deduped_2_2] * hoisted_6_1[deduped_2_2];
             return hoisted_18_1 * UnionOfRows( HomalgZeroMatrix( Sum( hoisted_16_1{[ 1 .. (logic_new_func_x_2 - 1) ]} ), deduped_1_2, hoisted_11_1 ), HomalgIdentityMatrix( deduped_1_2, hoisted_11_1 ), HomalgZeroMatrix( Sum( hoisted_16_1{[ (logic_new_func_x_2 + 1) .. hoisted_17_1 ]} ), deduped_1_2, hoisted_11_1 ) );
         end );
-    hoisted_2_1 := deduped_26_1;
-    hoisted_1_1 := deduped_25_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, LazyHList( deduped_22_1, function ( i_2 )
+    hoisted_2_1 := deduped_27_1;
+    hoisted_1_1 := deduped_26_1;
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, ValuesOnAllObjects, LazyHList( deduped_22_1, function ( i_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_20_1, hoisted_1_1[i_2], hoisted_2_1[i_2], UnderlyingMatrix, ConvertRowToMatrix( hoisted_19_1[i_2], hoisted_5_1[i_2], hoisted_6_1[i_2] ) );
           end ) );
 end
@@ -1491,7 +1504,7 @@ function ( cat_1, alpha_1 )
         end );
     hoisted_2_1 := List( deduped_7_1, Source );
     hoisted_1_1 := List( deduped_7_1, Range );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Range( alpha_1 ), Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, RightDivide( HomalgIdentityMatrix( hoisted_3_1[o_2], hoisted_4_1 ), hoisted_5_1[o_2] ) );
           end ) );
 end
@@ -1504,7 +1517,7 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    return ForAll( SetOfObjects( cat_1 ), function ( object_2 )
+    return ForAll( SetOfObjects( Source( cat_1 ) ), function ( object_2 )
             return IsZero( DecideZeroColumns( UnderlyingMatrix( arg3_1( object_2 ) ), UnderlyingMatrix( arg2_1( object_2 ) ) ) );
         end );
 end
@@ -1567,7 +1580,7 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    return ForAll( SetOfObjects( cat_1 ), function ( object_2 )
+    return ForAll( SetOfObjects( Source( cat_1 ) ), function ( object_2 )
             return IsZero( DecideZeroRows( UnderlyingMatrix( arg3_1( object_2 ) ), UnderlyingMatrix( arg2_1( object_2 ) ) ) );
         end );
 end
@@ -1620,7 +1633,7 @@ function ( cat_1, alpha_1, P_1 )
     hoisted_1_1 := List( deduped_4_1, function ( logic_new_func_x_2 )
             return SyzygiesOfRows( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( alpha_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, CreateCapCategoryObjectWithAttributes( hoisted_2_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), hoisted_3_1[o_2], UnderlyingMatrix, morphism_attr_1_2 );
@@ -1643,7 +1656,7 @@ function ( cat_1, alpha_1, T_1, tau_1, P_1 )
         end );
     hoisted_2_1 := List( deduped_5_1, UnderlyingMatrix );
     hoisted_1_1 := List( deduped_5_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := RightDivide( hoisted_2_1[o_2], hoisted_3_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -1658,24 +1671,25 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
-    deduped_10_1 := ValuesOnAllObjects( arg2_1 );
-    deduped_9_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_8_1 := Range( cat_1 );
-    deduped_7_1 := deduped_9_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
+    deduped_11_1 := ValuesOnAllObjects( arg2_1 );
+    deduped_10_1 := Range( cat_1 );
+    deduped_9_1 := Source( cat_1 );
+    deduped_8_1 := DefiningPairOfUnderlyingQuiver( deduped_9_1 );
+    deduped_7_1 := deduped_8_1[2];
     hoisted_6_1 := List( ValuesOfPreSheaf( Source( arg2_1 ) )[2], UnderlyingMatrix );
-    hoisted_5_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return SyzygiesOfRows( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
     hoisted_4_1 := deduped_7_1;
-    hoisted_3_1 := deduped_8_1;
-    hoisted_2_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_3_1 := deduped_10_1;
+    hoisted_2_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RowRankOfMatrix( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    hoisted_1_1 := List( deduped_10_1, function ( logic_new_func_x_2 )
+    hoisted_1_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
             return RankOfObject( Source( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_8_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_9_1, Range, deduped_10_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_8_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, hoisted_1_1[o_2] - hoisted_2_1[o_2] );
             end ), LazyHList( [ 1 .. Length( deduped_7_1 ) ], function ( m_2 )
                 local morphism_attr_1_2, deduped_2_2;
@@ -1702,7 +1716,7 @@ function ( cat_1, P_1, alpha_1, mu_1, alphap_1, Pp_1 )
     hoisted_1_1 := List( ValuesOnAllObjects( alpha_1 ), function ( logic_new_func_x_2 )
             return SyzygiesOfRows( UnderlyingMatrix( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local morphism_attr_1_2;
               morphism_attr_1_2 := RightDivide( hoisted_1_1[o_2] * hoisted_2_1[o_2], hoisted_3_1[o_2] );
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), CreateCapCategoryObjectWithAttributes( hoisted_4_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -1728,7 +1742,7 @@ function ( cat_1, s_1, a_1, L_1, r_1 )
     hoisted_3_1 := List( ValuesOfPreSheaf( a_1 )[1], RankOfObject );
     hoisted_2_1 := List( deduped_8_1, RankOfObject );
     hoisted_1_1 := deduped_8_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
               hoisted_2_2 := HomalgIdentityMatrix( hoisted_3_1[o_2], hoisted_4_1 );
               hoisted_1_2 := List( L_1, function ( logic_new_func_x_3 )
@@ -1762,7 +1776,7 @@ function ( cat_1, s_1, a_1, L_1, r_1 )
     hoisted_3_1 := UnderlyingRing( deduped_9_1 );
     hoisted_2_1 := List( ValuesOfPreSheaf( a_1 )[1], RankOfObject );
     hoisted_1_1 := List( deduped_8_1, RankOfObject );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
               hoisted_2_2 := HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 );
               hoisted_1_2 := List( L_1, function ( logic_new_func_x_3 )
@@ -1792,7 +1806,7 @@ function ( cat_1, a_1, r_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -1814,7 +1828,7 @@ function ( cat_1, a_1, s_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -1837,7 +1851,7 @@ function ( cat_1, iota_1, tau_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Source );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( tau_1 ), Source( iota_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( tau_1 ), Source( iota_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, RightDivide( hoisted_3_1[o_2], hoisted_4_1[o_2] ) );
           end ) );
 end
@@ -1856,7 +1870,7 @@ function ( cat_1, S_1, source_diagram_1, mat_1, range_diagram_1, T_1 )
     hoisted_3_1 := UnderlyingRing( deduped_5_1 );
     hoisted_2_1 := ValuesOfPreSheaf( T_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( S_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, S_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, S_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_2_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, hoisted_1_1[o_2], deduped_1_2, UnderlyingMatrix, UnionOfRows( hoisted_3_1, RankOfObject( deduped_1_2 ), ListN( List( source_diagram_1, function ( Si_3 )
@@ -1913,7 +1927,7 @@ function ( cat_1, morphisms_1, P_1 )
     hoisted_3_1 := deduped_11_1;
     hoisted_2_1 := UnderlyingRing( deduped_10_1 );
     hoisted_1_1 := ValuesOnAllObjects( deduped_9_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( deduped_9_1 ), P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2;
               deduped_9_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
@@ -1947,7 +1961,7 @@ function ( cat_1, r_1, a_1 )
     local hoisted_1_1, hoisted_2_1;
     hoisted_2_1 := Range( cat_1 );
     hoisted_1_1 := ValuesOnAllObjects( a_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, Source( deduped_1_2 ), Range( deduped_1_2 ), UnderlyingMatrix, r_1 * UnderlyingMatrix( deduped_1_2 ) );
@@ -1992,7 +2006,7 @@ function ( cat_1, beta_1, alpha_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] * hoisted_4_1[o_2] );
           end ) );
 end
@@ -2013,7 +2027,7 @@ function ( cat_1, alpha_1, beta_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_7_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Range( beta_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] * hoisted_4_1[o_2] );
           end ) );
 end
@@ -2034,7 +2048,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := [ k_1 + 1 .. Length( objects_1 ) ];
     hoisted_2_1 := [ 1 .. k_1 - 1 ];
     hoisted_1_1 := UnderlyingRing( deduped_7_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_6_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2, deduped_3_2;
               deduped_3_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -2062,7 +2076,7 @@ function ( cat_1, objects_1, k_1, P_1 )
     hoisted_3_1 := [ 1 .. k_1 - 1 ];
     hoisted_2_1 := ValuesOfPreSheaf( CAP_JIT_INCOMPLETE_LOGIC( deduped_7_1 ) )[1];
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_7_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, deduped_7_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := List( objects_1, function ( logic_new_func_x_3 )
                       return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -2092,7 +2106,7 @@ function ( cat_1, morphisms_1, k_1, P_1 )
     hoisted_3_1 := [ 1 .. deduped_11_1 ];
     hoisted_2_1 := deduped_11_1;
     hoisted_1_1 := UnderlyingRing( deduped_10_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( deduped_9_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Source( deduped_9_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
               deduped_8_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2122,19 +2136,20 @@ end
         
 ########
 function ( cat_1, arg2_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1;
-    deduped_11_1 := Length( arg2_1 );
-    deduped_10_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_9_1 := Range( cat_1 );
-    deduped_8_1 := deduped_10_1[2];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1;
+    deduped_12_1 := Length( arg2_1 );
+    deduped_11_1 := Range( cat_1 );
+    deduped_10_1 := Source( cat_1 );
+    deduped_9_1 := DefiningPairOfUnderlyingQuiver( deduped_10_1 );
+    deduped_8_1 := deduped_9_1[2];
     hoisted_7_1 := deduped_8_1;
-    hoisted_6_1 := deduped_9_1;
-    hoisted_5_1 := [ 2 .. deduped_11_1 ];
-    hoisted_4_1 := [ 1 .. deduped_11_1 - 1 ];
-    hoisted_3_1 := [ 1 .. deduped_11_1 ];
-    hoisted_2_1 := deduped_11_1;
-    hoisted_1_1 := UnderlyingRing( deduped_9_1 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_9_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_10_1[1] ], function ( o_2 )
+    hoisted_6_1 := deduped_11_1;
+    hoisted_5_1 := [ 2 .. deduped_12_1 ];
+    hoisted_4_1 := [ 1 .. deduped_12_1 - 1 ];
+    hoisted_3_1 := [ 1 .. deduped_12_1 ];
+    hoisted_2_1 := deduped_12_1;
+    hoisted_1_1 := UnderlyingRing( deduped_11_1 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_10_1, Range, deduped_11_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_9_1[1] ], function ( o_2 )
                 local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
                 deduped_5_2 := List( arg2_1, function ( logic_new_func_x_3 )
                         return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2223,7 +2238,7 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
     hoisted_3_1 := [ 1 .. deduped_16_1 ];
     hoisted_2_1 := deduped_16_1;
     hoisted_1_1 := UnderlyingRing( deduped_15_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2, deduped_11_2, deduped_12_2, deduped_13_2, deduped_14_2, deduped_15_2;
               deduped_15_2 := List( morphismsp_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2285,7 +2300,7 @@ function ( cat_1, s_1, L_1, a_1, r_1 )
     hoisted_3_1 := UnderlyingRing( deduped_9_1 );
     hoisted_2_1 := List( deduped_8_1, RankOfObject );
     hoisted_1_1 := deduped_8_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
               hoisted_2_2 := HomalgIdentityMatrix( hoisted_5_1[o_2], hoisted_3_1 );
               hoisted_1_2 := List( L_1, function ( logic_new_func_x_3 )
@@ -2319,7 +2334,7 @@ function ( cat_1, s_1, L_1, a_1, r_1 )
     hoisted_3_1 := deduped_10_1;
     hoisted_2_1 := UnderlyingRing( deduped_9_1 );
     hoisted_1_1 := List( deduped_8_1, RankOfObject );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
               hoisted_2_2 := HomalgIdentityMatrix( hoisted_4_1[o_2], hoisted_2_1 );
               hoisted_1_2 := List( L_1, function ( logic_new_func_x_3 )
@@ -2349,7 +2364,7 @@ function ( cat_1, a_1, r_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -2371,7 +2386,7 @@ function ( cat_1, a_1, s_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, a_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := hoisted_1_1[o_2];
               return CreateCapCategoryMorphismWithAttributes( hoisted_4_1, deduped_1_2, deduped_1_2, UnderlyingMatrix, HomalgIdentityMatrix( hoisted_2_1[o_2], hoisted_3_1 ) );
@@ -2395,7 +2410,7 @@ function ( cat_1, a_1, b_1 )
     hoisted_3_1 := List( deduped_6_1, UnderlyingMatrix );
     hoisted_2_1 := List( deduped_6_1, Range );
     hoisted_1_1 := List( deduped_6_1, Source );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( a_1 ), Range( a_1 ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, hoisted_3_1[o_2] + hoisted_4_1[o_2] );
           end ) );
 end
@@ -2414,7 +2429,7 @@ function ( cat_1, s_1, alpha_1, beta_1, r_1 )
     hoisted_3_1 := List( ValuesOnAllObjects( alpha_1 ), UnderlyingMatrix );
     hoisted_2_1 := ValuesOfPreSheaf( r_1 )[1];
     hoisted_1_1 := ValuesOfPreSheaf( s_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, KroneckerMat( hoisted_3_1[o_2], hoisted_4_1[o_2] ) );
           end ) );
 end
@@ -2427,19 +2442,20 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1;
-    deduped_9_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_8_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_7_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_6_1 := Range( cat_1 );
-    hoisted_5_1 := List( deduped_9_1[2], UnderlyingMatrix );
-    hoisted_4_1 := List( deduped_8_1[2], UnderlyingMatrix );
-    hoisted_3_1 := deduped_6_1;
-    hoisted_2_1 := List( deduped_9_1[1], RankOfObject );
-    hoisted_1_1 := List( deduped_8_1[1], RankOfObject );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_7_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1;
+    deduped_10_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_9_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_8_1 := Range( cat_1 );
+    deduped_7_1 := Source( cat_1 );
+    deduped_6_1 := DefiningPairOfUnderlyingQuiver( deduped_7_1 );
+    hoisted_5_1 := List( deduped_10_1[2], UnderlyingMatrix );
+    hoisted_4_1 := List( deduped_9_1[2], UnderlyingMatrix );
+    hoisted_3_1 := deduped_8_1;
+    hoisted_2_1 := List( deduped_10_1[1], RankOfObject );
+    hoisted_1_1 := List( deduped_9_1[1], RankOfObject );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_7_1, Range, deduped_8_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_6_1[1] ], function ( o_2 )
                 return CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, hoisted_1_1[o_2] * hoisted_2_1[o_2] );
-            end ), LazyHList( [ 1 .. Length( deduped_7_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_6_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := KroneckerMat( hoisted_4_1[m_2], hoisted_5_1[m_2] );
                 return CreateCapCategoryMorphismWithAttributes( hoisted_3_1, CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, NumberRows( morphism_attr_1_2 ) ), CreateCapCategoryObjectWithAttributes( hoisted_3_1, RankOfObject, NumberColumns( morphism_attr_1_2 ) ), UnderlyingMatrix, morphism_attr_1_2 );
@@ -2454,15 +2470,16 @@ end
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    hoisted_3_1 := HomalgIdentityMatrix( 1, UnderlyingRing( deduped_4_1 ) );
-    hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, RankOfObject, 1 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_3_1 := HomalgIdentityMatrix( 1, UnderlyingRing( deduped_6_1 ) );
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, RankOfObject, 1 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := hoisted_3_1;
                 return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, hoisted_1_1, hoisted_1_1, UnderlyingMatrix, morphism_attr_1_2 );
@@ -2477,15 +2494,16 @@ end
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_4_1 ) );
-    hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, RankOfObject, 0 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_3_1 := HomalgIdentityMatrix( 0, UnderlyingRing( deduped_6_1 ) );
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, RankOfObject, 0 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := hoisted_3_1;
                 return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, hoisted_1_1, hoisted_1_1, UnderlyingMatrix, morphism_attr_1_2 );
@@ -2507,7 +2525,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := deduped_6_1;
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := UnderlyingRing( deduped_6_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := HomalgIdentityMatrix( Sum( List( objects_1, function ( logic_new_func_x_3 )
                             return RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( logic_new_func_x_3 )[1][o_2] ) );
@@ -2534,7 +2552,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := deduped_6_1;
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, UnionOfRows( hoisted_4_1, hoisted_3_1[o_2], List( tau_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
                       end ) ) );
@@ -2564,7 +2582,7 @@ function ( cat_1, alpha_1, tau_1, I_1 )
     hoisted_1_1 := List( deduped_7_1, function ( logic_new_func_x_2 )
             return RankOfObject( Range( logic_new_func_x_2 ) );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( CAP_JIT_INCOMPLETE_LOGIC( tau_1[1] ) ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, I_1, Range( CAP_JIT_INCOMPLETE_LOGIC( tau_1[1] ) ), ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2, deduped_2_2;
               deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_5_1[o_2] );
               deduped_1_2 := RightDivide( HomalgIdentityMatrix( (hoisted_1_1[o_2] - hoisted_2_1[o_2]), hoisted_3_1 ) * hoisted_4_1[o_2], UnderlyingMatrix( deduped_2_2 ) );
@@ -2590,7 +2608,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_7_1, RankOfObject );
     hoisted_2_1 := deduped_8_1;
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], hoisted_4_1[o_2], hoisted_5_1 ) );
           end ) );
 end
@@ -2615,7 +2633,7 @@ function ( cat_1, morphisms_1, T_1, tau_1, P_1 )
     hoisted_3_1 := [ 1 .. deduped_11_1 ];
     hoisted_2_1 := deduped_11_1;
     hoisted_1_1 := UnderlyingRing( deduped_10_1 );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
               deduped_7_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2654,7 +2672,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := deduped_6_1;
     hoisted_1_1 := ValuesOfPreSheaf( P_1 )[1];
-    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, T_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( 0, hoisted_3_1[o_2], hoisted_4_1 ) );
           end ) );
 end
@@ -2674,7 +2692,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := UnderlyingRing( deduped_6_1 );
     hoisted_2_1 := List( deduped_5_1, RankOfObject );
     hoisted_1_1 := deduped_5_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local deduped_1_2;
               deduped_1_2 := UnionOfColumns( hoisted_3_1, hoisted_2_1[o_2], List( tau_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
@@ -2701,7 +2719,7 @@ function ( cat_1, objects_1, T_1, tau_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := ValuesOfPreSheaf( P_1 )[1];
     hoisted_1_1 := deduped_6_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, UnionOfColumns( hoisted_4_1, hoisted_3_1[o_2], List( tau_1, function ( logic_new_func_x_3 )
                           return UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) );
                       end ) ) );
@@ -2728,7 +2746,7 @@ function ( cat_1, morphisms_1, T_1, tau_1, P_1 )
     hoisted_3_1 := UnderlyingRing( deduped_10_1 );
     hoisted_2_1 := List( deduped_9_1, RankOfObject );
     hoisted_1_1 := deduped_9_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
               deduped_7_2 := List( morphisms_1, function ( logic_new_func_x_3 )
                       return RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( logic_new_func_x_3 )[o_2] ) ) );
@@ -2769,7 +2787,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_7_1, RankOfObject );
     hoisted_2_1 := deduped_8_1;
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], hoisted_4_1[o_2], hoisted_5_1 ) );
           end ) );
 end
@@ -2790,7 +2808,7 @@ function ( cat_1, T_1, P_1 )
     hoisted_3_1 := List( deduped_6_1, RankOfObject );
     hoisted_2_1 := ValuesOfPreSheaf( P_1 )[1];
     hoisted_1_1 := deduped_6_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, T_1, P_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], 0, hoisted_4_1 ) );
           end ) );
 end
@@ -2813,7 +2831,7 @@ function ( cat_1, a_1, b_1 )
     hoisted_3_1 := List( deduped_7_1, RankOfObject );
     hoisted_2_1 := deduped_8_1;
     hoisted_1_1 := deduped_7_1;
-    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, b_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( cat_1 )[1] ], function ( o_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, b_1, ValuesOnAllObjects, LazyHList( [ 1 .. DefiningPairOfUnderlyingQuiver( Source( cat_1 ) )[1] ], function ( o_2 )
               return CreateCapCategoryMorphismWithAttributes( hoisted_6_1, hoisted_1_1[o_2], hoisted_2_1[o_2], UnderlyingMatrix, HomalgZeroMatrix( hoisted_3_1[o_2], hoisted_4_1[o_2], hoisted_5_1 ) );
           end ) );
 end
@@ -2826,15 +2844,16 @@ end
         
 ########
 function ( cat_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1;
-    deduped_5_1 := DefiningPairOfUnderlyingQuiver( cat_1 );
-    deduped_4_1 := Range( cat_1 );
-    hoisted_3_1 := HomalgZeroMatrix( 0, 0, UnderlyingRing( deduped_4_1 ) );
-    hoisted_2_1 := deduped_4_1;
-    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_4_1, RankOfObject, 0 );
-    return CreateCapCategoryObjectWithAttributes( cat_1, Source, Source( cat_1 ), Range, deduped_4_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_5_1[1] ], function ( o_2 )
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1;
+    deduped_6_1 := Range( cat_1 );
+    deduped_5_1 := Source( cat_1 );
+    deduped_4_1 := DefiningPairOfUnderlyingQuiver( deduped_5_1 );
+    hoisted_3_1 := HomalgZeroMatrix( 0, 0, UnderlyingRing( deduped_6_1 ) );
+    hoisted_2_1 := deduped_6_1;
+    hoisted_1_1 := CreateCapCategoryObjectWithAttributes( deduped_6_1, RankOfObject, 0 );
+    return CreateCapCategoryObjectWithAttributes( cat_1, Source, deduped_5_1, Range, deduped_6_1, ValuesOfPreSheaf, NTuple( 2, LazyHList( [ 1 .. deduped_4_1[1] ], function ( o_2 )
                 return hoisted_1_1;
-            end ), LazyHList( [ 1 .. Length( deduped_5_1[2] ) ], function ( m_2 )
+            end ), LazyHList( [ 1 .. Length( deduped_4_1[2] ) ], function ( m_2 )
                 local morphism_attr_1_2;
                 morphism_attr_1_2 := hoisted_3_1;
                 return CreateCapCategoryMorphismWithAttributes( hoisted_2_1, hoisted_1_1, hoisted_1_1, UnderlyingMatrix, morphism_attr_1_2 );


### PR DESCRIPTION
thanks @zickgraf for the wonderful compiler 😄

* got rid of DefiningPairOfUnderlyingQuiver for PreSheaves/FunctorCategories/CoPreSheaves

and as suggested by @zickgraf:

* set compiler_hints.category_attribute_resolving_functions for the correct category
* appended ENHANCED_SYNTAX_TREE_ to the tree evaluation of the attributes to resolve