### PR TITLE
Remove unused logic template

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2022.12-15",
+Version := "2022.12-16",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/gap/CompilerLogic.gi
+++ b/gap/CompilerLogic.gi
@@ -118,14 +118,6 @@ CapJitAddLogicTemplate(
 
 CapJitAddLogicTemplate(
     rec(
-        variable_names := [ "number" ],
-        src_template := "Product( [ number, number, number ] )",
-        dst_template := "number ^ 3",
-    )
-);
-
-CapJitAddLogicTemplate(
-    rec(
         variable_names := [ "number1", "number2", "number3" ],
         src_template := "Product( [ number1, number2, number3 ] )",
         dst_template := "number1 * number2 * number3",


### PR DESCRIPTION
This logic template never matches due to the logic template following it. This is NOT due to the order of the logic templates (CompilerForCAP tries to match templates in the order in which they are added), but due to the compilation process: the syntax trees of the three numbers in the list are equal at the end of the compilation but differ at the beginning. Thus, the logic template for non-equal numbers kicks in first. A solution would be to rewrite `number * number * number` to `number ^ 3`, but in this case `number * number` also appears in the code and can be reused, so adding that rewrite rule would not improve things.