### PR TITLE
Adjust to https://github.com/homalg-project/FinSetsForCAP/pull/163

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -99,7 +99,7 @@ Dependencies := rec(
                    [ "CategoryConstructor", ">= 2022.11-11" ],
                    [ "SubcategoriesForCAP", ">= 2021.12-01" ],
                    [ "Toposes", ">= 2022.11-03" ],
-                   [ "FinSetsForCAP", ">= 2022.11-05" ],
+                   [ "FinSetsForCAP", ">= 2023.01-02" ],
                    ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/gap/precompiled_categories/FinBouquetsPrecompiled.gi
+++ b/gap/precompiled_categories/FinBouquetsPrecompiled.gi
@@ -138,7 +138,7 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_1_1 := deduped_14_1;
     return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_14_1, function ( x_2 )
                 local deduped_1_2, deduped_2_2;
-                deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + x_2] );
+                deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[(1 + x_2)] )] );
                 deduped_1_2 := REM_INT( QUO_INT( deduped_2_2, hoisted_2_1 ), hoisted_3_1 );
                 return deduped_1_2 + deduped_1_2 * hoisted_3_1 = hoisted_9_1[1 + REM_INT( deduped_2_2, hoisted_8_1 )] + hoisted_13_1[(1 + REM_INT( QUO_INT( deduped_2_2, hoisted_8_1 ), hoisted_12_1 ))] * hoisted_3_1;
             end ) ) );
@@ -197,7 +197,7 @@ function ( cat_1, source_1, range_1, alpha_1 )
     hoisted_1_1 := deduped_38_1;
     deduped_30_1 := Filtered( deduped_31_1, function ( x_2 )
             local deduped_1_2, deduped_2_2;
-            deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[1 + x_2] );
+            deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[(1 + x_2)] )] );
             deduped_1_2 := REM_INT( QUO_INT( deduped_2_2, hoisted_4_1 ), hoisted_5_1 );
             return deduped_1_2 + deduped_1_2 * hoisted_5_1 = hoisted_9_1[1 + REM_INT( deduped_2_2, hoisted_1_1 )] + hoisted_13_1[(1 + REM_INT( QUO_INT( deduped_2_2, hoisted_1_1 ), hoisted_12_1 ))] * hoisted_5_1;
         end );
@@ -293,7 +293,7 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_1_1 := deduped_26_1;
     deduped_25_1 := Filtered( deduped_26_1, function ( x_2 )
             local deduped_1_2, deduped_2_2;
-            deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + x_2] );
+            deduped_2_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[(1 + x_2)] )] );
             deduped_1_2 := REM_INT( QUO_INT( deduped_2_2, hoisted_2_1 ), hoisted_3_1 );
             return deduped_1_2 + deduped_1_2 * hoisted_3_1 = hoisted_9_1[1 + REM_INT( deduped_2_2, hoisted_8_1 )] + hoisted_13_1[(1 + REM_INT( QUO_INT( deduped_2_2, hoisted_8_1 ), hoisted_12_1 ))] * hoisted_3_1;
         end );

--- a/gap/precompiled_categories/FinQuiversPrecompiled.gi
+++ b/gap/precompiled_categories/FinQuiversPrecompiled.gi
@@ -153,7 +153,7 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_1_1 := deduped_21_1;
     return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_21_1, function ( x_2 )
                 local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-                deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + x_2] );
+                deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[(1 + x_2)] )] );
                 deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_11_1 );
                 deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_4_1 ), hoisted_3_1 );
                 deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_2_1 ), hoisted_3_1 );
@@ -248,7 +248,7 @@ function ( cat_1, source_1, range_1, alpha_1 )
     hoisted_1_1 := deduped_49_1;
     deduped_37_1 := Filtered( deduped_38_1, function ( x_2 )
             local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[1 + x_2] );
+            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[(1 + x_2)] )] );
             deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_1_1 );
             deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_6_1 ), hoisted_5_1 );
             deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_4_1 ), hoisted_5_1 );
@@ -380,7 +380,7 @@ function ( cat_1, arg2_1, arg3_1 )
     hoisted_1_1 := deduped_33_1;
     deduped_32_1 := Filtered( deduped_33_1, function ( x_2 )
             local deduped_1_2, deduped_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
-            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + x_2] );
+            deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[(1 + x_2)] )] );
             deduped_4_2 := 1 + REM_INT( deduped_5_2, hoisted_11_1 );
             deduped_3_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_4_1 ), hoisted_3_1 );
             deduped_2_2 := REM_INT( QUO_INT( deduped_5_2, hoisted_2_1 ), hoisted_3_1 );

--- a/gap/precompiled_categories/FinReflexiveQuiversPrecompiled.gi
+++ b/gap/precompiled_categories/FinReflexiveQuiversPrecompiled.gi
@@ -94,130 +94,131 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1;
-    deduped_50_1 := [ 1, 2, 3, 4 ];
-    deduped_49_1 := [ 1, 2, 3 ];
-    deduped_48_1 := [ 1, 2 ];
-    deduped_47_1 := DefiningQuadrupleOfReflexiveQuiver( arg2_1 );
-    deduped_46_1 := DefiningQuadrupleOfReflexiveQuiver( arg3_1 );
-    deduped_45_1 := deduped_46_1[4];
-    deduped_44_1 := deduped_47_1[4];
+    local hoisted_1_1, hoisted_2_1, hoisted_3_1, hoisted_4_1, hoisted_5_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1;
+    deduped_51_1 := [ 1, 2, 3, 4 ];
+    deduped_50_1 := [ 1, 2, 3 ];
+    deduped_49_1 := [ 1, 2 ];
+    deduped_48_1 := DefiningQuadrupleOfReflexiveQuiver( arg2_1 );
+    deduped_47_1 := DefiningQuadrupleOfReflexiveQuiver( arg3_1 );
+    deduped_46_1 := deduped_47_1[4];
+    deduped_45_1 := deduped_48_1[4];
+    deduped_44_1 := deduped_48_1[2];
     deduped_43_1 := deduped_47_1[2];
-    deduped_42_1 := deduped_46_1[2];
+    deduped_42_1 := deduped_48_1[1];
     deduped_41_1 := deduped_47_1[1];
-    deduped_40_1 := deduped_46_1[1];
-    deduped_39_1 := deduped_40_1 ^ deduped_43_1;
-    deduped_38_1 := deduped_42_1 ^ deduped_41_1;
-    deduped_37_1 := deduped_42_1 ^ deduped_43_1;
-    deduped_36_1 := deduped_40_1 ^ deduped_41_1;
-    deduped_35_1 := [ deduped_38_1, deduped_38_1, deduped_39_1, deduped_39_1, deduped_39_1, deduped_39_1 ];
-    deduped_34_1 := [ deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_39_1 ];
-    deduped_33_1 := [ 0 .. deduped_36_1 - 1 ];
-    deduped_32_1 := [ 0 .. deduped_37_1 - 1 ];
-    deduped_31_1 := [ 0 .. Product( deduped_34_1 ) - 1 ];
-    hoisted_5_1 := Product( deduped_34_1{deduped_50_1} );
-    hoisted_4_1 := deduped_39_1;
-    deduped_30_1 := List( deduped_31_1, function ( i_2 )
+    deduped_40_1 := deduped_41_1 ^ deduped_44_1;
+    deduped_39_1 := deduped_43_1 ^ deduped_42_1;
+    deduped_38_1 := deduped_43_1 ^ deduped_44_1;
+    deduped_37_1 := deduped_41_1 ^ deduped_42_1;
+    deduped_36_1 := [ deduped_39_1, deduped_39_1, deduped_40_1, deduped_40_1, deduped_40_1, deduped_40_1 ];
+    deduped_35_1 := [ deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_40_1 ];
+    deduped_34_1 := [ 0 .. deduped_37_1 - 1 ];
+    deduped_33_1 := [ 0 .. deduped_38_1 - 1 ];
+    deduped_32_1 := [ 0 .. Product( deduped_35_1 ) - 1 ];
+    hoisted_5_1 := Product( deduped_35_1{deduped_51_1} );
+    hoisted_4_1 := deduped_40_1;
+    deduped_31_1 := List( deduped_32_1, function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_5_1 ), hoisted_4_1 );
         end );
-    hoisted_3_1 := Product( deduped_34_1{deduped_49_1} );
-    deduped_29_1 := List( deduped_31_1, function ( i_2 )
+    hoisted_3_1 := Product( deduped_35_1{deduped_50_1} );
+    deduped_30_1 := List( deduped_32_1, function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_3_1 ), hoisted_4_1 );
         end );
-    hoisted_2_1 := deduped_38_1;
-    hoisted_1_1 := Product( deduped_34_1{deduped_48_1} );
-    deduped_28_1 := List( deduped_31_1, function ( i_2 )
+    hoisted_2_1 := deduped_39_1;
+    hoisted_1_1 := Product( deduped_35_1{deduped_49_1} );
+    deduped_29_1 := List( deduped_32_1, function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_1_1 ), hoisted_2_1 );
         end );
-    hoisted_25_1 := List( deduped_45_1, function ( a_2 )
+    hoisted_26_1 := List( deduped_46_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_16_1 := deduped_40_1;
-    hoisted_10_1 := [ 0 .. deduped_43_1 - 1 ];
-    hoisted_9_1 := deduped_42_1;
-    hoisted_26_1 := List( deduped_32_1, function ( i_2 )
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_25_1[(1 + REM_INT( QUO_INT( i_2, hoisted_9_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ) ), hoisted_9_1 ))] * hoisted_16_1 ^ k_3;
+    hoisted_17_1 := deduped_41_1;
+    hoisted_11_1 := [ 0 .. deduped_44_1 - 1 ];
+    hoisted_10_1 := deduped_43_1;
+    hoisted_27_1 := List( deduped_33_1, function ( i_2 )
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_26_1[(1 + REM_INT( QUO_INT( i_2, hoisted_10_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_10_1 ))] * hoisted_17_1 ^ k_3;
                   end ) );
         end );
-    hoisted_23_1 := List( deduped_44_1, function ( a_2 )
+    hoisted_24_1 := List( deduped_45_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_11_1 := [ 0 .. deduped_41_1 - 1 ];
-    hoisted_24_1 := List( deduped_33_1, function ( i_2 )
+    hoisted_12_1 := [ 0 .. deduped_42_1 - 1 ];
+    hoisted_25_1 := List( deduped_34_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_11_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_16_1 ^ j_3 ), hoisted_16_1 );
-                end );
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_23_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ))])] * hoisted_16_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_21_1 := List( deduped_45_1, function ( a_2 )
-            return a_2[1];
-        end );
-    hoisted_22_1 := List( deduped_32_1, function ( i_2 )
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_21_1[(1 + REM_INT( QUO_INT( i_2, hoisted_9_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ) ), hoisted_9_1 ))] * hoisted_16_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_19_1 := List( deduped_44_1, function ( a_2 )
-            return a_2[1];
-        end );
-    hoisted_20_1 := List( deduped_33_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_11_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_16_1 ^ j_3 ), hoisted_16_1 );
-                end );
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_19_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ))])] * hoisted_16_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_17_1 := deduped_46_1[3];
-    hoisted_18_1 := List( deduped_33_1, function ( i_2 )
-            return Sum( List( hoisted_11_1, function ( k_3 )
-                      return hoisted_17_1[(1 + REM_INT( QUO_INT( i_2, hoisted_16_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_16_1 ))] * hoisted_9_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_12_1 := deduped_47_1[3];
-    hoisted_15_1 := List( deduped_32_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_10_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_9_1 ^ j_3 ), hoisted_9_1 );
+            hoisted_1_2 := List( hoisted_12_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_17_1 ^ j_3 ), hoisted_17_1 );
                 end );
             return Sum( List( hoisted_11_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_12_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))])] * hoisted_9_1 ^ k_3;
+                      return hoisted_1_2[(1 + hoisted_24_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))])] * hoisted_17_1 ^ k_3;
                   end ) );
         end );
+    hoisted_22_1 := List( deduped_46_1, function ( a_2 )
+            return a_2[1];
+        end );
+    hoisted_23_1 := List( deduped_33_1, function ( i_2 )
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_22_1[(1 + REM_INT( QUO_INT( i_2, hoisted_10_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_10_1 ))] * hoisted_17_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_20_1 := List( deduped_45_1, function ( a_2 )
+            return a_2[1];
+        end );
+    hoisted_21_1 := List( deduped_34_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := List( hoisted_12_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_17_1 ^ j_3 ), hoisted_17_1 );
+                end );
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_20_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))])] * hoisted_17_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_18_1 := deduped_47_1[3];
+    hoisted_19_1 := List( deduped_34_1, function ( i_2 )
+            return Sum( List( hoisted_12_1, function ( k_3 )
+                      return hoisted_18_1[(1 + REM_INT( QUO_INT( i_2, hoisted_17_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ) ), hoisted_17_1 ))] * hoisted_10_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_13_1 := deduped_48_1[3];
+    hoisted_16_1 := List( deduped_33_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := List( hoisted_11_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_10_1 ^ j_3 ), hoisted_10_1 );
+                end );
+            return Sum( List( hoisted_12_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_13_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ))])] * hoisted_10_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_15_1 := deduped_38_1;
     hoisted_14_1 := deduped_37_1;
-    hoisted_13_1 := deduped_36_1;
-    hoisted_27_1 := [ List( deduped_31_1, function ( logic_new_func_x_2 )
-                return hoisted_15_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_13_1 ), hoisted_14_1 )];
-            end ), List( deduped_31_1, function ( logic_new_func_x_2 )
-                return hoisted_18_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
-            end ), List( deduped_31_1, function ( logic_new_func_x_2 )
-                return hoisted_20_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
-            end ), List( deduped_31_1, function ( logic_new_func_x_2 )
-                return hoisted_22_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_13_1 ), hoisted_14_1 )];
-            end ), List( deduped_31_1, function ( logic_new_func_x_2 )
-                return hoisted_24_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
-            end ), List( deduped_31_1, function ( logic_new_func_x_2 )
-                return hoisted_26_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_13_1 ), hoisted_14_1 )];
+    hoisted_28_1 := [ List( deduped_32_1, function ( logic_new_func_x_2 )
+                return hoisted_16_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_14_1 ), hoisted_15_1 )];
+            end ), List( deduped_32_1, function ( logic_new_func_x_2 )
+                return hoisted_19_1[1 + REM_INT( logic_new_func_x_2, hoisted_14_1 )];
+            end ), List( deduped_32_1, function ( logic_new_func_x_2 )
+                return hoisted_21_1[1 + REM_INT( logic_new_func_x_2, hoisted_14_1 )];
+            end ), List( deduped_32_1, function ( logic_new_func_x_2 )
+                return hoisted_23_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_14_1 ), hoisted_15_1 )];
+            end ), List( deduped_32_1, function ( logic_new_func_x_2 )
+                return hoisted_25_1[1 + REM_INT( logic_new_func_x_2, hoisted_14_1 )];
+            end ), List( deduped_32_1, function ( logic_new_func_x_2 )
+                return hoisted_27_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_14_1 ), hoisted_15_1 )];
             end ) ];
-    hoisted_8_1 := [ 0, 1, 2, 3, 4, 5 ];
-    hoisted_7_1 := [ 1, deduped_38_1, Product( deduped_35_1{deduped_48_1} ), Product( deduped_35_1{deduped_49_1} ), Product( deduped_35_1{deduped_50_1} ), Product( deduped_35_1{[ 1, 2, 3, 4, 5 ]} ) ];
-    hoisted_6_1 := [ deduped_28_1, deduped_28_1, deduped_29_1, deduped_29_1, deduped_30_1, deduped_30_1 ];
-    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_31_1, function ( x_2 )
+    hoisted_9_1 := [ 0, 1, 2, 3, 4, 5 ];
+    hoisted_8_1 := [ 1, deduped_39_1, Product( deduped_36_1{deduped_49_1} ), Product( deduped_36_1{deduped_50_1} ), Product( deduped_36_1{deduped_51_1} ), Product( deduped_36_1{[ 1, 2, 3, 4, 5 ]} ) ];
+    hoisted_7_1 := deduped_32_1;
+    hoisted_6_1 := [ deduped_29_1, deduped_29_1, deduped_30_1, deduped_30_1, deduped_31_1, deduped_31_1 ];
+    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_32_1, function ( x_2 )
                 local hoisted_1_2;
-                hoisted_1_2 := 1 + x_2;
-                return Sum( hoisted_8_1, function ( j_3 )
+                hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_7_1[(1 + x_2)] );
+                return Sum( hoisted_9_1, function ( j_3 )
                           local deduped_1_3;
                           deduped_1_3 := 1 + j_3;
-                          return hoisted_6_1[deduped_1_3][hoisted_1_2] * hoisted_7_1[deduped_1_3];
-                      end ) = Sum( hoisted_8_1, function ( j_3 )
+                          return hoisted_6_1[deduped_1_3][hoisted_1_2] * hoisted_8_1[deduped_1_3];
+                      end ) = Sum( hoisted_9_1, function ( j_3 )
                           local deduped_1_3;
                           deduped_1_3 := 1 + j_3;
-                          return hoisted_27_1[deduped_1_3][hoisted_1_2] * hoisted_7_1[deduped_1_3];
+                          return hoisted_28_1[deduped_1_3][hoisted_1_2] * hoisted_8_1[deduped_1_3];
                       end );
             end ) ) );
 end
@@ -271,106 +272,106 @@ function ( cat_1, source_1, range_1, alpha_1 )
     deduped_46_1 := List( deduped_49_1, function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_3_1 ), hoisted_4_1 );
         end );
-    hoisted_25_1 := List( deduped_68_1, function ( a_2 )
+    hoisted_26_1 := List( deduped_68_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_12_1 := deduped_57_1;
-    hoisted_11_1 := deduped_66_1;
+    hoisted_13_1 := deduped_57_1;
+    hoisted_12_1 := deduped_66_1;
     hoisted_2_1 := deduped_65_1;
-    hoisted_26_1 := List( deduped_50_1, function ( i_2 )
-            return Sum( List( hoisted_12_1, function ( k_3 )
-                      return hoisted_25_1[(1 + REM_INT( QUO_INT( i_2, hoisted_11_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ) ), hoisted_11_1 ))] * hoisted_2_1 ^ k_3;
+    hoisted_27_1 := List( deduped_50_1, function ( i_2 )
+            return Sum( List( hoisted_13_1, function ( k_3 )
+                      return hoisted_26_1[(1 + REM_INT( QUO_INT( i_2, hoisted_12_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_13_1[(1 + k_3)] ) ), hoisted_12_1 ))] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_23_1 := List( deduped_67_1, function ( a_2 )
+    hoisted_24_1 := List( deduped_67_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_13_1 := deduped_56_1;
-    hoisted_24_1 := List( deduped_51_1, function ( i_2 )
+    hoisted_14_1 := deduped_56_1;
+    hoisted_25_1 := List( deduped_51_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_13_1, function ( j_3 )
+            hoisted_1_2 := List( hoisted_14_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_2_1 ^ j_3 ), hoisted_2_1 );
                 end );
-            return Sum( List( hoisted_12_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_23_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ))])] * hoisted_2_1 ^ k_3;
+            return Sum( List( hoisted_13_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_24_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_13_1[(1 + k_3)] ))])] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_21_1 := List( deduped_68_1, function ( a_2 )
+    hoisted_22_1 := List( deduped_68_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_22_1 := List( deduped_50_1, function ( i_2 )
-            return Sum( List( hoisted_12_1, function ( k_3 )
-                      return hoisted_21_1[(1 + REM_INT( QUO_INT( i_2, hoisted_11_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ) ), hoisted_11_1 ))] * hoisted_2_1 ^ k_3;
+    hoisted_23_1 := List( deduped_50_1, function ( i_2 )
+            return Sum( List( hoisted_13_1, function ( k_3 )
+                      return hoisted_22_1[(1 + REM_INT( QUO_INT( i_2, hoisted_12_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_13_1[(1 + k_3)] ) ), hoisted_12_1 ))] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_19_1 := List( deduped_67_1, function ( a_2 )
+    hoisted_20_1 := List( deduped_67_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_20_1 := List( deduped_51_1, function ( i_2 )
+    hoisted_21_1 := List( deduped_51_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_13_1, function ( j_3 )
+            hoisted_1_2 := List( hoisted_14_1, function ( j_3 )
                     return REM_INT( QUO_INT( i_2, hoisted_2_1 ^ j_3 ), hoisted_2_1 );
                 end );
-            return Sum( List( hoisted_12_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_19_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ))])] * hoisted_2_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_17_1 := deduped_71_1[3];
-    hoisted_18_1 := List( deduped_51_1, function ( i_2 )
             return Sum( List( hoisted_13_1, function ( k_3 )
-                      return hoisted_17_1[(1 + REM_INT( QUO_INT( i_2, hoisted_2_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_13_1[(1 + k_3)] ) ), hoisted_2_1 ))] * hoisted_11_1 ^ k_3;
+                      return hoisted_1_2[(1 + hoisted_20_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_13_1[(1 + k_3)] ))])] * hoisted_2_1 ^ k_3;
                   end ) );
         end );
-    hoisted_14_1 := deduped_70_1[3];
-    hoisted_16_1 := List( deduped_50_1, function ( i_2 )
+    hoisted_18_1 := deduped_71_1[3];
+    hoisted_19_1 := List( deduped_51_1, function ( i_2 )
+            return Sum( List( hoisted_14_1, function ( k_3 )
+                      return hoisted_18_1[(1 + REM_INT( QUO_INT( i_2, hoisted_2_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_14_1[(1 + k_3)] ) ), hoisted_2_1 ))] * hoisted_12_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_15_1 := deduped_70_1[3];
+    hoisted_17_1 := List( deduped_50_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_12_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_11_1 ^ j_3 ), hoisted_11_1 );
+            hoisted_1_2 := List( hoisted_13_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_12_1 ^ j_3 ), hoisted_12_1 );
                 end );
-            return Sum( List( hoisted_13_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_14_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_13_1[(1 + k_3)] ))])] * hoisted_11_1 ^ k_3;
+            return Sum( List( hoisted_14_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_15_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_14_1[(1 + k_3)] ))])] * hoisted_12_1 ^ k_3;
                   end ) );
         end );
-    hoisted_15_1 := deduped_60_1;
+    hoisted_16_1 := deduped_60_1;
     hoisted_1_1 := deduped_59_1;
-    hoisted_27_1 := [ List( deduped_49_1, function ( logic_new_func_x_2 )
-                return hoisted_16_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_1_1 ), hoisted_15_1 )];
+    hoisted_28_1 := [ List( deduped_49_1, function ( logic_new_func_x_2 )
+                return hoisted_17_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_1_1 ), hoisted_16_1 )];
             end ), List( deduped_49_1, function ( logic_new_func_x_2 )
-                return hoisted_18_1[1 + REM_INT( logic_new_func_x_2, hoisted_1_1 )];
+                return hoisted_19_1[1 + REM_INT( logic_new_func_x_2, hoisted_1_1 )];
             end ), List( deduped_49_1, function ( logic_new_func_x_2 )
-                return hoisted_20_1[1 + REM_INT( logic_new_func_x_2, hoisted_1_1 )];
+                return hoisted_21_1[1 + REM_INT( logic_new_func_x_2, hoisted_1_1 )];
             end ), List( deduped_49_1, function ( logic_new_func_x_2 )
-                return hoisted_22_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_1_1 ), hoisted_15_1 )];
+                return hoisted_23_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_1_1 ), hoisted_16_1 )];
             end ), List( deduped_49_1, function ( logic_new_func_x_2 )
-                return hoisted_24_1[1 + REM_INT( logic_new_func_x_2, hoisted_1_1 )];
+                return hoisted_25_1[1 + REM_INT( logic_new_func_x_2, hoisted_1_1 )];
             end ), List( deduped_49_1, function ( logic_new_func_x_2 )
-                return hoisted_26_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_1_1 ), hoisted_15_1 )];
+                return hoisted_27_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_1_1 ), hoisted_16_1 )];
             end ) ];
-    hoisted_10_1 := [ 0, 1, 2, 3, 4, 5 ];
-    hoisted_9_1 := [ 1, deduped_61_1, Product( deduped_55_1{deduped_72_1} ), Product( deduped_55_1{deduped_73_1} ), Product( deduped_55_1{deduped_74_1} ), Product( deduped_55_1{[ 1, 2, 3, 4, 5 ]} ) ];
+    hoisted_11_1 := [ 0, 1, 2, 3, 4, 5 ];
+    hoisted_10_1 := [ 1, deduped_61_1, Product( deduped_55_1{deduped_72_1} ), Product( deduped_55_1{deduped_73_1} ), Product( deduped_55_1{deduped_74_1} ), Product( deduped_55_1{[ 1, 2, 3, 4, 5 ]} ) ];
+    hoisted_9_1 := deduped_49_1;
     hoisted_8_1 := [ deduped_46_1, deduped_46_1, deduped_47_1, deduped_47_1, deduped_48_1, deduped_48_1 ];
     deduped_45_1 := Filtered( deduped_49_1, function ( x_2 )
             local hoisted_1_2;
-            hoisted_1_2 := 1 + x_2;
-            return Sum( hoisted_10_1, function ( j_3 )
+            hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[(1 + x_2)] );
+            return Sum( hoisted_11_1, function ( j_3 )
                       local deduped_1_3;
                       deduped_1_3 := 1 + j_3;
-                      return hoisted_8_1[deduped_1_3][hoisted_1_2] * hoisted_9_1[deduped_1_3];
-                  end ) = Sum( hoisted_10_1, function ( j_3 )
+                      return hoisted_8_1[deduped_1_3][hoisted_1_2] * hoisted_10_1[deduped_1_3];
+                  end ) = Sum( hoisted_11_1, function ( j_3 )
                       local deduped_1_3;
                       deduped_1_3 := 1 + j_3;
-                      return hoisted_27_1[deduped_1_3][hoisted_1_2] * hoisted_9_1[deduped_1_3];
+                      return hoisted_28_1[deduped_1_3][hoisted_1_2] * hoisted_10_1[deduped_1_3];
                   end );
         end );
     deduped_44_1 := [ 0 .. Length( deduped_45_1 ) - 1 ];
     hoisted_42_1 := List( [ 0 .. deduped_60_1 * deduped_64_1 - 1 ], function ( i_2 )
-            return REM_INT( QUO_INT( i_2, hoisted_11_1 ^ QUO_INT( i_2, hoisted_15_1 ) ), hoisted_11_1 );
+            return REM_INT( QUO_INT( i_2, hoisted_12_1 ^ QUO_INT( i_2, hoisted_16_1 ) ), hoisted_12_1 );
         end );
     hoisted_41_1 := deduped_64_1;
-    hoisted_29_1 := deduped_49_1;
-    hoisted_28_1 := deduped_45_1;
+    hoisted_29_1 := deduped_45_1;
     hoisted_38_1 := List( deduped_44_1, function ( i_2 )
-            return REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_29_1[1 + hoisted_28_1[(1 + i_2)]] ), hoisted_1_1 ), hoisted_15_1 );
+            return REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[1 + hoisted_29_1[(1 + i_2)]] ), hoisted_1_1 ), hoisted_16_1 );
         end );
     hoisted_30_1 := AsList( alpha_1 );
     hoisted_40_1 := List( deduped_58_1, function ( i_2 )
@@ -381,14 +382,14 @@ function ( cat_1, source_1, range_1, alpha_1 )
     hoisted_43_1 := List( deduped_53_1, function ( logic_new_func_x_2 )
             local deduped_1_2;
             deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_39_1[1 + logic_new_func_x_2] );
-            return hoisted_42_1[1 + (hoisted_40_1[1 + REM_INT( deduped_1_2, hoisted_33_1 )] + REM_INT( QUO_INT( deduped_1_2, hoisted_33_1 ), hoisted_41_1 ) * hoisted_15_1)];
+            return hoisted_42_1[1 + (hoisted_40_1[1 + REM_INT( deduped_1_2, hoisted_33_1 )] + REM_INT( QUO_INT( deduped_1_2, hoisted_33_1 ), hoisted_41_1 ) * hoisted_16_1)];
         end );
     hoisted_36_1 := List( [ 0 .. deduped_59_1 * deduped_63_1 - 1 ], function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_2_1 ^ QUO_INT( i_2, hoisted_1_1 ) ), hoisted_2_1 );
         end );
     hoisted_35_1 := deduped_63_1;
     hoisted_31_1 := List( deduped_44_1, function ( i_2 )
-            return REM_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_29_1[1 + hoisted_28_1[(1 + i_2)]] ), hoisted_1_1 );
+            return REM_INT( CAP_JIT_INCOMPLETE_LOGIC( hoisted_9_1[1 + hoisted_29_1[(1 + i_2)]] ), hoisted_1_1 );
         end );
     hoisted_34_1 := List( deduped_58_1, function ( i_2 )
             return hoisted_31_1[1 + hoisted_30_1[(1 + i_2)]];
@@ -451,127 +452,127 @@ function ( cat_1, arg2_1, arg3_1 )
     deduped_41_1 := List( deduped_44_1, function ( i_2 )
             return REM_INT( QUO_INT( i_2, hoisted_1_1 ), hoisted_2_1 );
         end );
-    hoisted_25_1 := List( deduped_60_1, function ( a_2 )
+    hoisted_26_1 := List( deduped_60_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_16_1 := deduped_55_1;
-    hoisted_10_1 := deduped_49_1;
-    hoisted_9_1 := deduped_57_1;
-    hoisted_26_1 := List( deduped_45_1, function ( i_2 )
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_25_1[(1 + REM_INT( QUO_INT( i_2, hoisted_9_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ) ), hoisted_9_1 ))] * hoisted_16_1 ^ k_3;
+    hoisted_17_1 := deduped_55_1;
+    hoisted_11_1 := deduped_49_1;
+    hoisted_10_1 := deduped_57_1;
+    hoisted_27_1 := List( deduped_45_1, function ( i_2 )
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_26_1[(1 + REM_INT( QUO_INT( i_2, hoisted_10_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_10_1 ))] * hoisted_17_1 ^ k_3;
                   end ) );
         end );
-    hoisted_23_1 := List( deduped_59_1, function ( a_2 )
+    hoisted_24_1 := List( deduped_59_1, function ( a_2 )
             return a_2[2];
         end );
-    hoisted_11_1 := deduped_50_1;
-    hoisted_24_1 := List( deduped_46_1, function ( i_2 )
+    hoisted_12_1 := deduped_50_1;
+    hoisted_25_1 := List( deduped_46_1, function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_11_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_16_1 ^ j_3 ), hoisted_16_1 );
-                end );
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_23_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ))])] * hoisted_16_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_21_1 := List( deduped_60_1, function ( a_2 )
-            return a_2[1];
-        end );
-    hoisted_22_1 := List( deduped_45_1, function ( i_2 )
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_21_1[(1 + REM_INT( QUO_INT( i_2, hoisted_9_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ) ), hoisted_9_1 ))] * hoisted_16_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_19_1 := List( deduped_59_1, function ( a_2 )
-            return a_2[1];
-        end );
-    hoisted_20_1 := List( deduped_46_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_11_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_16_1 ^ j_3 ), hoisted_16_1 );
-                end );
-            return Sum( List( hoisted_10_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_19_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_10_1[(1 + k_3)] ))])] * hoisted_16_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_17_1 := deduped_61_1[3];
-    hoisted_18_1 := List( deduped_46_1, function ( i_2 )
-            return Sum( List( hoisted_11_1, function ( k_3 )
-                      return hoisted_17_1[(1 + REM_INT( QUO_INT( i_2, hoisted_16_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_16_1 ))] * hoisted_9_1 ^ k_3;
-                  end ) );
-        end );
-    hoisted_12_1 := deduped_62_1[3];
-    hoisted_15_1 := List( deduped_45_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := List( hoisted_10_1, function ( j_3 )
-                    return REM_INT( QUO_INT( i_2, hoisted_9_1 ^ j_3 ), hoisted_9_1 );
+            hoisted_1_2 := List( hoisted_12_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_17_1 ^ j_3 ), hoisted_17_1 );
                 end );
             return Sum( List( hoisted_11_1, function ( k_3 )
-                      return hoisted_1_2[(1 + hoisted_12_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))])] * hoisted_9_1 ^ k_3;
+                      return hoisted_1_2[(1 + hoisted_24_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))])] * hoisted_17_1 ^ k_3;
                   end ) );
         end );
-    hoisted_14_1 := deduped_52_1;
-    hoisted_13_1 := deduped_51_1;
-    hoisted_27_1 := [ List( deduped_44_1, function ( logic_new_func_x_2 )
-                return hoisted_15_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_13_1 ), hoisted_14_1 )];
+    hoisted_22_1 := List( deduped_60_1, function ( a_2 )
+            return a_2[1];
+        end );
+    hoisted_23_1 := List( deduped_45_1, function ( i_2 )
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_22_1[(1 + REM_INT( QUO_INT( i_2, hoisted_10_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ) ), hoisted_10_1 ))] * hoisted_17_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_20_1 := List( deduped_59_1, function ( a_2 )
+            return a_2[1];
+        end );
+    hoisted_21_1 := List( deduped_46_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := List( hoisted_12_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_17_1 ^ j_3 ), hoisted_17_1 );
+                end );
+            return Sum( List( hoisted_11_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_20_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_11_1[(1 + k_3)] ))])] * hoisted_17_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_18_1 := deduped_61_1[3];
+    hoisted_19_1 := List( deduped_46_1, function ( i_2 )
+            return Sum( List( hoisted_12_1, function ( k_3 )
+                      return hoisted_18_1[(1 + REM_INT( QUO_INT( i_2, hoisted_17_1 ^ CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ) ), hoisted_17_1 ))] * hoisted_10_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_13_1 := deduped_62_1[3];
+    hoisted_16_1 := List( deduped_45_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := List( hoisted_11_1, function ( j_3 )
+                    return REM_INT( QUO_INT( i_2, hoisted_10_1 ^ j_3 ), hoisted_10_1 );
+                end );
+            return Sum( List( hoisted_12_1, function ( k_3 )
+                      return hoisted_1_2[(1 + hoisted_13_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_12_1[(1 + k_3)] ))])] * hoisted_10_1 ^ k_3;
+                  end ) );
+        end );
+    hoisted_15_1 := deduped_52_1;
+    hoisted_14_1 := deduped_51_1;
+    hoisted_28_1 := [ List( deduped_44_1, function ( logic_new_func_x_2 )
+                return hoisted_16_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_14_1 ), hoisted_15_1 )];
             end ), List( deduped_44_1, function ( logic_new_func_x_2 )
-                return hoisted_18_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
+                return hoisted_19_1[1 + REM_INT( logic_new_func_x_2, hoisted_14_1 )];
             end ), List( deduped_44_1, function ( logic_new_func_x_2 )
-                return hoisted_20_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
+                return hoisted_21_1[1 + REM_INT( logic_new_func_x_2, hoisted_14_1 )];
             end ), List( deduped_44_1, function ( logic_new_func_x_2 )
-                return hoisted_22_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_13_1 ), hoisted_14_1 )];
+                return hoisted_23_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_14_1 ), hoisted_15_1 )];
             end ), List( deduped_44_1, function ( logic_new_func_x_2 )
-                return hoisted_24_1[1 + REM_INT( logic_new_func_x_2, hoisted_13_1 )];
+                return hoisted_25_1[1 + REM_INT( logic_new_func_x_2, hoisted_14_1 )];
             end ), List( deduped_44_1, function ( logic_new_func_x_2 )
-                return hoisted_26_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_13_1 ), hoisted_14_1 )];
+                return hoisted_27_1[1 + REM_INT( QUO_INT( logic_new_func_x_2, hoisted_14_1 ), hoisted_15_1 )];
             end ) ];
-    hoisted_8_1 := [ 0, 1, 2, 3, 4, 5 ];
-    hoisted_7_1 := [ 1, deduped_53_1, Product( deduped_48_1{deduped_63_1} ), Product( deduped_48_1{deduped_64_1} ), Product( deduped_48_1{deduped_65_1} ), Product( deduped_48_1{[ 1, 2, 3, 4, 5 ]} ) ];
+    hoisted_9_1 := [ 0, 1, 2, 3, 4, 5 ];
+    hoisted_8_1 := [ 1, deduped_53_1, Product( deduped_48_1{deduped_63_1} ), Product( deduped_48_1{deduped_64_1} ), Product( deduped_48_1{deduped_65_1} ), Product( deduped_48_1{[ 1, 2, 3, 4, 5 ]} ) ];
+    hoisted_7_1 := deduped_44_1;
     hoisted_6_1 := [ deduped_41_1, deduped_41_1, deduped_42_1, deduped_42_1, deduped_43_1, deduped_43_1 ];
     deduped_40_1 := Filtered( deduped_44_1, function ( x_2 )
             local hoisted_1_2;
-            hoisted_1_2 := 1 + x_2;
-            return Sum( hoisted_8_1, function ( j_3 )
+            hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_7_1[(1 + x_2)] );
+            return Sum( hoisted_9_1, function ( j_3 )
                       local deduped_1_3;
                       deduped_1_3 := 1 + j_3;
-                      return hoisted_6_1[deduped_1_3][hoisted_1_2] * hoisted_7_1[deduped_1_3];
-                  end ) = Sum( hoisted_8_1, function ( j_3 )
+                      return hoisted_6_1[deduped_1_3][hoisted_1_2] * hoisted_8_1[deduped_1_3];
+                  end ) = Sum( hoisted_9_1, function ( j_3 )
                       local deduped_1_3;
                       deduped_1_3 := 1 + j_3;
-                      return hoisted_27_1[deduped_1_3][hoisted_1_2] * hoisted_7_1[deduped_1_3];
+                      return hoisted_28_1[deduped_1_3][hoisted_1_2] * hoisted_8_1[deduped_1_3];
                   end );
         end );
     deduped_39_1 := Length( deduped_40_1 );
     deduped_38_1 := [ 0 .. deduped_39_1 - 1 ];
     hoisted_37_1 := List( [ 0 .. deduped_52_1 * deduped_58_1 - 1 ], function ( i_2 )
-            return REM_INT( QUO_INT( i_2, hoisted_9_1 ^ QUO_INT( i_2, hoisted_14_1 ) ), hoisted_9_1 );
+            return REM_INT( QUO_INT( i_2, hoisted_10_1 ^ QUO_INT( i_2, hoisted_15_1 ) ), hoisted_10_1 );
         end );
     hoisted_35_1 := deduped_58_1;
     hoisted_36_1 := List( deduped_49_1, function ( logic_new_func_x_2 )
             return REM_INT( logic_new_func_x_2, hoisted_35_1 );
         end );
     hoisted_34_1 := List( [ 0 .. deduped_51_1 * deduped_56_1 - 1 ], function ( i_2 )
-            return REM_INT( QUO_INT( i_2, hoisted_16_1 ^ QUO_INT( i_2, hoisted_13_1 ) ), hoisted_16_1 );
+            return REM_INT( QUO_INT( i_2, hoisted_17_1 ^ QUO_INT( i_2, hoisted_14_1 ) ), hoisted_17_1 );
         end );
     hoisted_32_1 := deduped_56_1;
     hoisted_33_1 := List( deduped_50_1, function ( logic_new_func_x_2 )
             return REM_INT( logic_new_func_x_2, hoisted_32_1 );
         end );
-    hoisted_31_1 := deduped_44_1;
-    hoisted_30_1 := deduped_40_1;
-    hoisted_29_1 := deduped_39_1;
-    hoisted_28_1 := deduped_38_1;
+    hoisted_31_1 := deduped_40_1;
+    hoisted_30_1 := deduped_39_1;
+    hoisted_29_1 := deduped_38_1;
     return List( deduped_38_1, function ( logic_new_func_x_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2;
-            deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_28_1[1 + logic_new_func_x_2] );
-            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_31_1[1 + hoisted_30_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_28_1[(1 + REM_INT( QUO_INT( deduped_4_2, hoisted_29_1 ^ QUO_INT( deduped_4_2, hoisted_29_1 ) ), hoisted_29_1 ))] ))]] );
-            hoisted_2_2 := REM_INT( QUO_INT( deduped_3_2, hoisted_13_1 ), hoisted_14_1 );
-            hoisted_1_2 := REM_INT( deduped_3_2, hoisted_13_1 );
-            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfReflexiveQuiverMorphism, NTuple( 2, List( hoisted_11_1, function ( logic_new_func_x_3 )
-                        return hoisted_34_1[1 + (hoisted_1_2 + hoisted_33_1[(1 + logic_new_func_x_3)] * hoisted_13_1)];
-                    end ), List( hoisted_10_1, function ( logic_new_func_x_3 )
-                        return hoisted_37_1[1 + (hoisted_2_2 + hoisted_36_1[(1 + logic_new_func_x_3)] * hoisted_14_1)];
+            deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_29_1[1 + logic_new_func_x_2] );
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_7_1[1 + hoisted_31_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_29_1[(1 + REM_INT( QUO_INT( deduped_4_2, hoisted_30_1 ^ QUO_INT( deduped_4_2, hoisted_30_1 ) ), hoisted_30_1 ))] ))]] );
+            hoisted_2_2 := REM_INT( QUO_INT( deduped_3_2, hoisted_14_1 ), hoisted_15_1 );
+            hoisted_1_2 := REM_INT( deduped_3_2, hoisted_14_1 );
+            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfReflexiveQuiverMorphism, NTuple( 2, List( hoisted_12_1, function ( logic_new_func_x_3 )
+                        return hoisted_34_1[1 + (hoisted_1_2 + hoisted_33_1[(1 + logic_new_func_x_3)] * hoisted_14_1)];
+                    end ), List( hoisted_11_1, function ( logic_new_func_x_3 )
+                        return hoisted_37_1[1 + (hoisted_2_2 + hoisted_36_1[(1 + logic_new_func_x_3)] * hoisted_15_1)];
                     end ) ) );
         end );
 end


### PR DESCRIPTION
This introduces some small regressions which will be fixed in an upcoming CAP PR.

Note: The diff in `gap/precompiled_categories/FinReflexiveQuiversPrecompiled.gi` is similar to the other diffs but looks much larger due to shifted variable names.